### PR TITLE
feat: issue assignment awareness and full comment context in all workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to claude-workflows are documented here.
+
+Format: `[version] - YYYY-MM-DD`
+Types: `Added`, `Changed`, `Fixed`, `Removed`
+
+---
+
+## [Unreleased]
+
+## [1.1.0] - 2026-03-13
+
+### Added
+
+- **`/drain-issues`**: Self-assign issues at wave start — claims all issues in the wave before launching subagents, preventing conflicts in team environments
+- **`/drain-issues`**: Assignment filter — skips issues already assigned to someone else by default
+- **`/drain-issues`**: `--get-all` flag — override the assignment filter and process all open issues regardless of who they are assigned to
+- **All issue commands**: Full comment context — `gh issue view` now fetches `comments` field so agents read the full issue thread (body + all comments) before touching code. Affected: `/drain-issues`, `/quick-fix`, `/batch-issues`, `/issue-pipeline`
+- **README**: New design principle — *Full issue context*
+- **CHANGELOG.md**: This file
+
+### Changed
+
+- **`/drain-issues` Phase 1**: Fetch payload now includes `assignees` and `comments` fields
+- **`/drain-issues` Phase 4**: New Step 4.0 runs `gh issue edit --add-assignee @me` for every issue before subagents start
+- **`/batch-issues`**: Subagent prompt now explicitly fetches issue with comments before analysis
+- **`/issue-pipeline`**: Fix phase subagent now fetches comments as a dedicated step
+- **`/quick-fix`**: Context fetch updated to include `comments` in `--json` fields
+- **README**: `/drain-issues` how-it-works steps and options table updated
+
+---
+
+## [1.0.0] - 2026-02-01
+
+### Added
+
+- `/commit` — Stage changes and create conventional commits
+- `/pr` — Create detailed PRs with documentation and changelog
+- `/fix-issue` — End-to-end issue fix with worktrees and TDD
+- `/quick-fix` — Autonomous fix with minimal checkpoints
+- `/create-issue` — Create well-structured GitHub issues
+- `/review-pr` — Review a PR for changelog alignment and merge safety
+- `/review-changes` — Meticulous diff review for breaking changes and regressions
+- `/scan-debt` — Scan for tech debt, code smells, and security issues
+- `/batch-issues` — Process multiple issues in parallel using subagents
+- `/drain-issues` — Dependency-aware wave processing until backlog is empty
+- `/issue-pipeline` — Full pipeline: create issue → fix → PR → review
+- `/full-review` — Claude ↔ Codex iterative review loop

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Process multiple issues in parallel using subagents. Simple parallel execution w
 1. Gathers the issue list based on your filter
 2. Shows the list and waits for confirmation
 3. Launches parallel subagents (max 3) — each in its own worktree
-4. Each agent: understands issue → writes failing test → fixes → creates PR
+4. Each agent: fetches issue body + all comments → writes failing test → fixes → creates PR
 5. Aggregates results into a summary table
 6. Optionally batch-reviews all created PRs
 
@@ -229,6 +229,7 @@ Autonomous issue processor — analyzes dependencies between issues, batches ind
 /drain-issues --skip-review                         # create PRs without review (faster)
 /drain-issues --full-review                         # Claude↔Codex review loop per PR
 /drain-issues label:bug --full-review --no-merge    # combine flags
+/drain-issues --get-all                             # include issues assigned to others
 ```
 
 **Options:**
@@ -241,16 +242,18 @@ Autonomous issue processor — analyzes dependencies between issues, batches ind
 | `--no-merge` | `false` | Create and review PRs but don't auto-merge |
 | `--skip-review` | `false` | Create PRs without the review phase |
 | `--full-review` | `false` | Use Claude↔Codex review loop instead of basic review |
+| `--get-all` | `false` | Process all open issues regardless of assignment. By default, issues already assigned to someone else are skipped |
 
 **How it works:**
-1. Fetches all open issues (or filtered subset)
+1. Fetches all open issues (or filtered subset), skipping issues assigned to others (unless `--get-all`)
 2. Analyzes dependencies between issues (explicit `#ref`, shared files, sequential chains)
 3. Groups independent issues into waves
 4. Presents wave plan and waits for confirmation
-5. Processes each wave: parallel subagents in worktrees → PRs → review → merge
-6. Cleans up worktrees after each merge
-7. Moves to next wave until all issues are processed
-8. Final summary with merged PRs, failed items, and cleanup commands
+5. **Assigns itself** to all issues in the wave before starting work (claims them)
+6. Processes each wave: parallel subagents in worktrees → PRs → review → merge
+7. Cleans up worktrees after each merge
+8. Moves to next wave until all issues are processed
+9. Final summary with merged PRs, failed items, and cleanup commands
 
 **Wave example:**
 ```
@@ -352,6 +355,7 @@ Open Claude Code and type `/` — you should see the commands in autocomplete.
 ## Key design principles
 
 - **Git worktrees for isolation** — `/fix-issue`, `/quick-fix`, `/batch-issues`, and `/drain-issues` create worktrees so you can work on multiple issues in parallel without conflicts
+- **Full issue context** — Commands fetch the issue body *and all comments* before touching code. Reproduction steps, design decisions, and constraints often live in the thread, not the original description
 - **Root cause over surface fixes** — Commands explicitly warn against z-index hacks, retry loops, and other band-aids. They push for understanding *why* before fixing
 - **Test-driven fixes** — Write a failing test first, then implement the fix
 - **Conventional commits** — All commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) spec

--- a/batch-issues.md
+++ b/batch-issues.md
@@ -73,7 +73,8 @@ For issue #12, #15, #18 - Launch 3 parallel Task agents:
 Task 1: "Process issue #12 end-to-end:
 - Detect default branch: git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo 'main'
 - Create worktree ../fix-12-<desc> from origin/<default-branch>
-- Understand the issue
+- Fetch full issue with comments: `gh issue view 12 --json number,title,body,labels,comments`
+- Read the issue body AND all comments — comments often contain reproduction steps, clarifications, or constraints
 - Identify ROOT CAUSE (not surface-level symptoms)
 - Write a failing test that reproduces the bug
 - Create a brief implementation plan

--- a/drain-issues.md
+++ b/drain-issues.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git:*), Bash(gh:*), Task
-argument-hint: [label:filter] [--max-parallel=N] [--dry-run]
+argument-hint: [label:filter] [--max-parallel=N] [--dry-run] [--get-all]
 description: Autonomous issue processor - analyzes dependencies, batches independent issues, repeats until done
 ---
 
@@ -28,6 +28,7 @@ Arguments: **$ARGUMENTS**
 | `--no-merge` | false | Review PRs but don't auto-merge |
 | `--skip-review` | false | Create PRs without review/merge |
 | `--full-review` | false | Use Claude↔Codex review loop instead of basic review. Codex reviews each PR, Claude fixes issues, repeat until approved (max 15 iterations per PR). Much more thorough but slower (~5-15 min per PR). |
+| `--get-all` | false | Process all open issues regardless of who is assigned. Without this flag, issues already assigned to someone else are skipped. |
 
 ---
 
@@ -47,13 +48,34 @@ Arguments: **$ARGUMENTS**
 ## Phase 1: Fetch All Open Issues
 
 ```bash
-# Get all open issues with full details
-gh issue list --state open --json number,title,body,labels --limit 50
+# Get all open issues with full details (including assignees)
+gh issue list --state open --json number,title,body,labels,assignees --limit 50
 ```
 
 If a label filter was provided:
 ```bash
-gh issue list --state open --label "<label>" --json number,title,body,labels --limit 50
+gh issue list --state open --label "<label>" --json number,title,body,labels,assignees --limit 50
+```
+
+### Assignment Filtering
+
+After fetching, get your own GitHub username:
+```bash
+gh api user --jq '.login'
+```
+
+Then filter the issue list:
+
+- **Default behavior:** Skip any issue where `assignees` is non-empty AND none of the assignees is you. These belong to someone else — don't touch them.
+- **`--get-all` mode:** Include all issues regardless of assignment. Issues assigned to others are still claimed (you'll be added as assignee in Phase 4).
+- **Unassigned issues** (empty `assignees`): always included.
+- **Issues already assigned to you:** always included.
+
+Log any skipped issues clearly:
+```
+Skipped (assigned to others):
+  #17 - Refactor auth middleware  [assigned: alice]
+  #23 - Fix payment bug           [assigned: bob, carol]
 ```
 
 ---
@@ -119,6 +141,21 @@ Total: 4 waves to process 10 issues
 
 ## Phase 4: Process Current Wave
 
+### Step 4.0: Claim Issues (Self-Assign)
+
+Before launching any subagents, assign yourself to every issue in this wave:
+
+```bash
+# Assign yourself to all issues in the wave before starting work
+for issue in <wave-issue-numbers>; do
+  gh issue edit $issue --add-assignee @me
+done
+```
+
+This marks the issues as in-progress so other contributors (or other `/drain-issues` sessions) don't pick them up simultaneously.
+
+### Step 4.1: Launch Subagents
+
 For each issue in the current wave, launch parallel subagents:
 
 ```
@@ -128,7 +165,8 @@ Each agent receives:
 "Process issue #XX end-to-end:
 - Detect default branch: git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo 'main'
 - Create worktree ../fix-XX-<short-desc> from origin/<default-branch>
-- Read and understand the issue fully
+- Fetch the full issue including all comments: `gh issue view XX --json number,title,body,labels,comments`
+- Read the issue body AND all comments — comments often contain reproduction steps, clarifications, or constraints that are critical to the correct solution
 - Identify ROOT CAUSE (not surface-level symptoms — no z-index hacks, no retry loops without understanding why)
 - Write a failing test that reproduces the bug
 - Create a brief implementation plan

--- a/issue-pipeline.md
+++ b/issue-pipeline.md
@@ -84,7 +84,8 @@ Use the Task tool to spawn a subagent with the following prompt:
 Instructions:
 1. Detect default branch: git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo 'main'
 2. Create a git worktree from origin/<default-branch>
-3. Read and understand the issue fully
+3. Fetch the full issue including all comments: `gh issue view <number> --json number,title,body,labels,comments`
+   Read the issue body AND all comments — comments often contain reproduction steps, clarifications, or constraints that are critical to the correct solution.
 4. Investigate the codebase to find ROOT CAUSE — do NOT apply surface-level fixes (z-index hacks, retry loops, overflow-hidden). Ask 'why does this happen?' until you reach the actual cause.
 5. Write a failing test that reproduces the bug
 6. Create a brief implementation plan

--- a/quick-fix.md
+++ b/quick-fix.md
@@ -9,7 +9,7 @@ description: Fast autonomous fix - minimal checkpoints, maximum automation
 ## Context
 
 Issue to fix:
-!`gh issue view $ARGUMENTS --json number,title,body,labels`
+!`gh issue view $ARGUMENTS --json number,title,body,labels,comments`
 
 Repository:
 !`git remote get-url origin`


### PR DESCRIPTION
## Summary

- `/drain-issues` skips issues assigned to others by default; self-assigns the whole wave before starting
- New `--get-all` flag to override assignment filtering
- All issue commands (`/drain-issues`, `/quick-fix`, `/batch-issues`, `/issue-pipeline`) now fetch the full issue thread (body + comments) before touching code
- Add `CHANGELOG.md` with dated entries

## Changes

| File | What changed |
|------|-------------|
| `drain-issues.md` | Assignment filter in Phase 1; `--get-all` flag; Step 4.0 self-assign loop |
| `quick-fix.md` | Added `comments` to `--json` fetch |
| `batch-issues.md` | Subagent prompt fetches comments explicitly |
| `issue-pipeline.md` | Fix phase subagent fetches comments as a dedicated step |
| `README.md` | `--get-all` documented; new *Full issue context* design principle |
| `CHANGELOG.md` | New file with v1.0.0 and v1.1.0 entries |

## Test plan

- [ ] Run `/drain-issues --dry-run` on a repo with assigned issues — verify assigned ones are skipped in the wave plan
- [ ] Run `/drain-issues --get-all --dry-run` — verify all issues appear in the plan
- [ ] Run `/quick-fix <number>` and confirm the context section includes comments
- [ ] Verify `CHANGELOG.md` renders correctly on GitHub

Closes #1