### PR TITLE
fix(drain-issues): correctly handle umbrella/epic issues in dependency analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,25 @@ Types: `Added`, `Changed`, `Fixed`, `Removed`
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-03-13
+
+### Fixed
+
+- **`/drain-issues`**: Umbrella/epic issues no longer block their sub-issues from being claimed and processed — tracking references (`- [ ] #12` checklists) are no longer treated as blocking dependencies
+
 ### Added
 
+- **`/drain-issues`**: Explicit umbrella/epic detection in Phase 2 — issues identified by title keywords (`Epic`, `Umbrella`, `Tracking`, `Meta`), checklist body pattern, or self-description as trackers
+- **`/drain-issues`**: Umbrella placement rule in Phase 3 — epics with their own implementation work go into Wave 1 alongside sub-issues; purely tracking epics are skipped
+
+### Changed
+
+- **`/drain-issues`**: Dependency analysis now distinguishes *blocking references* (`depends on`, `blocked by`, `after #X`, `requires #X`) from *tracking references* (umbrella → sub-issues); only blocking references create wave dependencies
 - **`/issue-pipeline`**: `--plan-review` flag — optional Claude↔Codex plan refinement loop before implementation; Claude writes a plan, Codex critiques it, Claude refines, repeat up to 3 rounds (1 original + 2 refinements); proceeds to implement with the best plan regardless
 - **`/issue-pipeline`**: Prompt Enhancement Phase — Codex pre-analyzes the issue before the fix agent runs, producing a precise problem statement with root cause hypothesis, affected files, edge cases, and success criteria
 - **`/issue-pipeline`**: Improvement Passes (post-implementation) — up to 2 Codex-powered quality passes after review completes; each pass generates a fresh prompt in a new context window focused on improving abstraction, naming, and edge case coverage
 - **`/fix-issue`**: Tool inventory block in plan mode — explicitly lists all available tools and requires the plan to include steps for running tests, linter, and type checker
-
-### Changed
-
 - **`/fix-issue`**: Guardrails updated — linter/type checker is now a required pre-commit step alongside the full test suite
-- **`/fix-issue`**: Step numbering updated to account for the new linter step
 - **`/issue-pipeline`**: Step 6 now explicitly instructs agents to account for all available tools when creating implementation plans
 
 ## [1.1.0] - 2026-03-13

--- a/drain-issues.md
+++ b/drain-issues.md
@@ -86,19 +86,30 @@ For each issue, analyze for dependencies:
 
 ### Dependency Indicators
 
-1. **Explicit references:** Issue mentions `#<number>`, "depends on", "blocked by", "after #X"
-2. **Shared files:** Issues that likely touch the same files (based on description)
-3. **Sequential requirements:** "Step 2 of...", "Follow-up to..."
-4. **Feature dependencies:** Issue B needs feature from Issue A
+1. **Blocking references (creates dependency):** "depends on #X", "blocked by #X", "after #X", "requires #X", "follow-up to #X", "Step N of..."
+2. **Tracking references (NOT a dependency):** Umbrella/epic issues that list sub-issues (e.g. "Sub-tasks: #12, #15, #22" or "This epic tracks: #12, #15"). These are **trackers**, not blockers — the sub-issues are independent and can run in parallel.
+3. **Shared files:** Issues that likely touch the same files (based on description)
+4. **Feature dependencies:** Issue B needs a feature that Issue A introduces
+
+### CRITICAL: Umbrella/Epic Detection
+
+An issue is an **umbrella/epic** if:
+- Its title contains words like "Epic", "Umbrella", "Tracking", "Meta"
+- Its body uses checklist format listing multiple issues: `- [ ] #12`, `- [x] #15`
+- It describes itself as tracking progress across multiple issues
+
+**Umbrella issues do NOT block their sub-issues.** Sub-issues are independent. Place sub-issues in Wave 1 (or their appropriate wave based on their own dependencies), and the umbrella issue either:
+- Gets processed in parallel with the sub-issues (if it has its own implementation work), or
+- Is skipped/deferred if it has no independent work beyond tracking
 
 ### Analysis Process
 
 ```
 For each issue:
-  1. Read issue body for explicit issue references (#XX)
-  2. Extract mentioned files/components
-  3. Look for dependency keywords
-  4. Build dependency graph
+  1. Check if it's an umbrella/epic — if so, mark it and do NOT treat its referenced issues as dependents
+  2. Read issue body for BLOCKING dependency keywords (depends on, blocked by, after #X, requires #X)
+  3. Extract mentioned files/components
+  4. Build dependency graph using only blocking relationships
 ```
 
 ### Dependency Graph Output
@@ -127,13 +138,17 @@ Unclear (need manual review):
 Group independent issues into waves:
 
 ```
-Wave 1: [#12, #15, #22, #41] - 4 independent issues
+Wave 1: [#12, #15, #22, #41] - 4 independent issues (including sub-issues of any umbrella)
 Wave 2: [#18, #28, #33] - 3 issues (after wave 1 deps resolve)
 Wave 3: [#24, #32] - 2 issues (depend on wave 2)
 Wave 4: [#35] - 1 issue (depends on wave 3)
 
+Umbrella/Epic issues: [#10 - Epic: Dashboard] → placed in Wave 1 alongside sub-issues (or skipped if tracking-only)
+
 Total: 4 waves to process 10 issues
 ```
+
+**Umbrella placement rule:** Umbrella issues with their own implementation work go into Wave 1 as independent. Umbrella issues that are purely tracking (no code to write) can be skipped — they'll auto-close when sub-issues are linked and closed.
 
 **Present the wave plan to the user and wait for confirmation before proceeding.**
 


### PR DESCRIPTION
## Summary

- Detects umbrella/epic issues in Phase 2 by title keywords, checklist body pattern, or self-description as trackers
- Tracking references (umbrella → sub-issues checklists) no longer create wave dependency edges
- Sub-issues are now placed in Wave 1 and claimed alongside other independent issues
- Phase 3 documents the umbrella placement rule (epic with own work → Wave 1; tracking-only → skip)

## Root Cause

The agent saw `- [ ] #12` / `- [x] #15` in an umbrella body and treated them as "umbrella depends on these issues to exist first", producing a single-issue Wave 1 (just the umbrella) and deferring everything else.

## Test plan

- [ ] Run `/drain-issues` on a repo with an epic/umbrella issue referencing sub-issues — all sub-issues should appear in Wave 1 and be claimed
- [ ] Confirm true blocking deps (`depends on #X`) still create correct wave ordering
- [ ] Confirm purely tracking epics (no code) are skipped in the wave plan

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)