### PR TITLE
docs(changelog): add missing /drain-issues --plan-review entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Types: `Added`, `Changed`, `Fixed`, `Removed`
 
 ## [Unreleased]
 
+### Added
+
+- **`/drain-issues`**: `--plan-review` flag — optional Codex plan review loop before implementation; each subagent writes a plan, Codex critiques it (max 3 rounds), then implements the refined plan; catches design issues early before any code is written
+
 ## [1.2.0] - 2026-03-13
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Adds the missing changelog entry for `/drain-issues --plan-review` flag that was shipped in PR #7 but omitted from CHANGELOG.md

## Test plan
- [x] Changelog format is consistent with existing entries
- [x] Entry placed under `[Unreleased]` section