### PR TITLE
fix(workflows): use Codex flags that actually parse (review rejects -s/-a; exec rejects -a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Types: `Added`, `Changed`, `Fixed`, `Removed`
 
 ### Fixed
 
-- **`/issue-pipeline` + `/drain-issues`**: corrected broken Codex invocations — prompts are now piped via stdin (positional args silently hang on large prompts), `--full-auto` replaced with version-safe `-s <mode> -a never` (it errors on the `review` subcommand in codex-cli 0.136.0), and the `/issue-pipeline` full-review loop now uses `codex exec review -` without `--base` (which is mutually exclusive with a custom prompt), diffing in-prompt instead — Fixes #14
+- **`/full-review` + `/issue-pipeline` + `/drain-issues`**: corrected Codex invocations to flags that actually parse on codex-cli 0.136.0 — prompts piped via stdin (positional args silently hang); plain `codex exec` uses `-s <mode>` only (non-interactive auto-approves — `-a`/`--ask-for-approval` is a global flag and errors after `exec`); `codex exec review` uses only `--ephemeral --json --title` (it rejects `-s`, `-a`, and `--full-auto`, and runs read-only by default); the `/issue-pipeline` full-review loop uses `codex exec review -` without `--base` (mutually exclusive with a custom prompt), diffing in-prompt — Fixes #14, #16
 
 ## [1.2.0] - 2026-03-13
 

--- a/drain-issues.md
+++ b/drain-issues.md
@@ -238,7 +238,7 @@ Run TWO distinct passes in sequence. Merging them dilutes both.
 - Append every Codex output to `.pair/REVIEW.md` with a `## Round N — <pass-name>` header. Pass the file in subsequent prompts so Codex doesn't re-raise dismissed issues.
 - Always pipe prompts via stdin (large prompts as positional args silently hang per CLAUDE.md).
 - Capture stderr — empty stdout ≠ approval. Retry once on empty output. If second attempt also empty, log warning and proceed without plan-review for this issue.
-- Use: `printf '%s' "$PROMPT" | codex exec - -s read-only -a never --ephemeral --json` (read-only sandbox signals review intent, faster). Do NOT use `--full-auto` — it is an undocumented legacy alias that errors on the `review` subcommand; use the explicit `-s <mode> -a never` pair everywhere.
+- Use: `printf '%s' "$PROMPT" | codex exec - -s read-only --ephemeral --json` (read-only sandbox signals review intent, faster). `codex exec` is non-interactive and auto-approves within the sandbox — no `-a`/`--ask-for-approval` (that's a global flag and errors after `exec`) and no `--full-auto` (legacy alias; errors on `review`). The `codex exec review` subcommand takes neither `-s` nor `-a`.
 
 ---
 
@@ -400,7 +400,7 @@ for each PR in [#45, #46, #47]:
        b. Execute the /full-review workflow inline:
           - Get PR info and checkout the branch
           - Initialize iteration history
-          - Run Codex review via `codex exec review - -s workspace-write -a never --ephemeral --json` with the prompt piped on stdin (including iteration history context on rounds 2+); do NOT use `--full-auto`
+          - Run Codex review via `codex exec review - --ephemeral --json` with the prompt piped on stdin (including iteration history context on rounds 2+); do NOT use `--full-auto`
           - Use Codex's default model only; do not pass `--model` or `-c model=...`
           - Parse review for [P1]/[P2] issues
           - Fix issues, commit, push

--- a/full-review.md
+++ b/full-review.md
@@ -113,7 +113,7 @@ Build the Codex review prompt. It includes the three review gates, scope guardra
 
 **IMPORTANT — command form.** `codex exec review --base <branch>` is **mutually exclusive with a custom PROMPT**. We need a custom prompt, so we use `codex exec review` *without* `--base` and instruct Codex in-prompt to diff `HEAD` against `origin/$BASE_BRANCH`.
 
-**IMPORTANT — flags.** Use `-s workspace-write -a never` (verified on codex-cli 0.136.0). Do **NOT** use `--full-auto` — it errors on the `review` subcommand. Use Codex's default model (no `--model` / no `-c model=...`).
+**IMPORTANT — flags (verified on codex-cli 0.136.0).** `codex exec review` accepts NEITHER `-s/--sandbox` NOR `-a/--ask-for-approval` NOR `--full-auto` — passing any of them errors (`unexpected argument '-s' found`). It runs read-only + non-interactive by default. Use only `--ephemeral --json --title`. Use Codex's default model (no `--model` / no `-c model=...`).
 
 **Prompt template (all iterations) — assemble into `$REVIEW_PROMPT`:**
 
@@ -209,7 +209,7 @@ CODEX_OUT=$(mktemp -t codex-review-out-XXXX.jsonl)
 CODEX_ERR=$(mktemp -t codex-review-err-XXXX.log)
 
 printf '%s' "$REVIEW_PROMPT" |
-  codex exec review - -s workspace-write -a never --ephemeral --json \
+  codex exec review - --ephemeral --json \
     --title "$PR_TITLE" \
     > "$CODEX_OUT" 2> "$CODEX_ERR"
 
@@ -345,7 +345,7 @@ Follow-up issues opened (if any):
 
 ## Important Notes
 
-- The review runs with `-s workspace-write` so Codex can read all project files (and the linked issue context baked into the prompt) for context. `-a never` skips approval prompts. `--full-auto` is **not** used — it errors on the `review` subcommand in codex-cli 0.136.0.
+- The `codex exec review` subcommand runs read-only + non-interactive by default, so it can read all project files (and the linked issue context baked into the prompt) without any sandbox/approval flags. It rejects `-s`, `-a`, and `--full-auto` — pass only `--ephemeral --json --title` (verified on codex-cli 0.136.0).
 - Tags: `[P1]` critical, `[P2]` major, `[P3]` minor — suffixed with `[AC]` (acceptance criteria) or `[SECURITY]` for those gates. Only `[P1]`/`[P2]` block approval.
 - The iteration history is passed to Codex each round so it knows what was fixed/dismissed. If Codex re-raises a *correctness* issue already dismissed, skip it. **Never** skip a re-raised `[AC]`/`[SECURITY]` issue on those grounds.
 - Approval is gated on the `VERDICT:` line AND zero open `[P1]`/`[P2]` across all three gates — not on fuzzy phrases like "looks good".

--- a/issue-pipeline.md
+++ b/issue-pipeline.md
@@ -98,7 +98,7 @@ Output a precise problem statement that includes:
 
 Be specific and technical. This will be passed directly to a coding agent."
 
-ENHANCED_PROBLEM=$(printf '%s' "$ENHANCE_PROMPT" | codex exec - -s read-only -a never --ephemeral --json 2>/dev/null | python3 -c "
+ENHANCED_PROBLEM=$(printf '%s' "$ENHANCE_PROMPT" | codex exec - -s read-only --ephemeral --json 2>/dev/null | python3 -c "
 import json, sys
 result = None
 for line in sys.stdin:
@@ -234,7 +234,7 @@ DIAGNOSIS_CONFIRMED | DIAGNOSIS_NEEDS_REVISION
 
 Be specific. Cite line numbers. If you find no issues after honest search, say so explicitly."
 
-printf '%s' "$DIAG_PROMPT" | codex exec - -s read-only -a never --ephemeral --json 2> "$CODEX_ERR"
+printf '%s' "$DIAG_PROMPT" | codex exec - -s read-only --ephemeral --json 2> "$CODEX_ERR"
 ```
 
 Parse last `item.completed` / `agent_message` from JSONL. Append to `.pair/REVIEW.md`.
@@ -284,7 +284,7 @@ FIX_APPROVED | FIX_NEEDS_REVISION
 
 Be specific. Cite line numbers. No vague 'consider edge cases'."
 
-printf '%s' "$FIX_PROMPT" | codex exec - -s read-only -a never --ephemeral --json 2> "$CODEX_ERR"
+printf '%s' "$FIX_PROMPT" | codex exec - -s read-only --ephemeral --json 2> "$CODEX_ERR"
 ```
 
 Parse last `agent_message`. Append to `.pair/REVIEW.md`.
@@ -347,7 +347,7 @@ Run the full Claude↔Codex review loop for this PR inline:
    a. Build Codex prompt:
       - Iteration 1: `review`
       - Iteration N>1: Include `ITERATION_HISTORY` with instructions to skip dismissed/fixed issues
-   b. Run Codex review with the default model only — pipe the prompt via stdin: `printf '%s' "$REVIEW_PROMPT" | codex exec review - -s workspace-write -a never --ephemeral --json --title "..." 2> "$CODEX_ERR"`
+   b. Run Codex review with the default model only — pipe the prompt via stdin: `printf '%s' "$REVIEW_PROMPT" | codex exec review - --ephemeral --json --title "..." 2> "$CODEX_ERR"`
       Omit `--base` (it is mutually exclusive with a custom prompt) — instruct Codex in-prompt to diff `HEAD` vs `origin/$BASE_BRANCH`. Do NOT use `--full-auto` (errors on the `review` subcommand). Do not pass `--model` or `-c model=...`. Capture stderr; empty stdout ≠ approval.
    c. Parse JSONL output for the last `agent_message` text
    d. If no [P1]/[P2] issues → **APPROVED**, break
@@ -392,7 +392,7 @@ Write a prompt that:
 
 Be concrete. Don't suggest rewrites — suggest targeted improvements to the existing code."
 
-IMPROVEMENT_PROMPT=$(printf '%s' "$IMPROVE_PROMPT" | codex exec - -s read-only -a never --ephemeral --json 2>/dev/null | python3 -c "
+IMPROVEMENT_PROMPT=$(printf '%s' "$IMPROVE_PROMPT" | codex exec - -s read-only --ephemeral --json 2>/dev/null | python3 -c "
 import json, sys
 result = None
 for line in sys.stdin:


### PR DESCRIPTION
## Summary

Hotfix for #16. The #11/#14 changes used Codex flags that **error at runtime** — caught while running `/full-review` on a live PR (`error: unexpected argument '-s' found`).

## Root cause

- `codex exec review` accepts **neither** `-s/--sandbox` **nor** `-a/--ask-for-approval` **nor** `--full-auto`. It runs read-only + non-interactive by default. Correct: `codex exec review - --ephemeral --json --title "<t>"`.
- `-a/--ask-for-approval` is a **global** flag (before the subcommand), not an `exec` flag — `codex exec -a never` errors. Non-interactive `codex exec` auto-approves within the sandbox, so no approval flag is needed.

## Verified-correct forms (codex-cli 0.136.0)

- Plain exec: `printf '%s' "$P" | codex exec - -s read-only --ephemeral --json`
- Review:     `printf '%s' "$P" | codex exec review - --ephemeral --json --title "<t>"`

Both confirmed empirically (review help has zero of those flags; `codex exec -a never` rejected; `codex exec - -s read-only` ran clean and returned output).

Fixes #16