### PR TITLE
feat(skills): add Codex-native port of the workflow suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .claude/
+.pair/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Types: `Added`, `Changed`, `Fixed`, `Removed`
 ### Added
 
 - **`/drain-issues`**: `--plan-review` flag — optional Codex plan review loop before implementation; each subagent writes a plan, Codex critiques it (max 3 rounds), then implements the refined plan; catches design issues early before any code is written
+- **Codex port**: Added [`skills/gh-workflow-suite`](skills/gh-workflow-suite), a Codex-native skill that ports the repo's Claude workflows to Codex skills and review primitives
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A collection of slash commands for [Claude Code](https://docs.anthropic.com/en/d
 
 Drop these into `~/.claude/commands/` and get a complete CI-like pipeline inside your terminal.
 
+This repo now also includes a Codex-native port under [`skills/gh-workflow-suite`](skills/gh-workflow-suite), since the local Codex install on this machine does not expose a comparable slash-command directory.
+
 ## Quick overview
 
 | Command | Description |
@@ -362,6 +364,24 @@ cp path/to/claude-workflows/*.md .claude/commands/
 ### Verify installation
 
 Open Claude Code and type `/` — you should see the commands in autocomplete.
+
+## Codex Port
+
+The Codex equivalent in this repo is the [`gh-workflow-suite`](skills/gh-workflow-suite) skill.
+
+Use it with prompts such as:
+
+```text
+Use $gh-workflow-suite to run the /fix-issue flow for issue #42.
+Use $gh-workflow-suite to emulate /issue-pipeline for "add rate limiting" with --plan-review.
+Use $gh-workflow-suite to run /review-pr for PR #123.
+```
+
+Porting notes:
+
+- Codex uses a skill here instead of a slash-command directory.
+- Parallel workflows such as `/batch-issues` and `/drain-issues` only use sub-agents when the user explicitly asks for delegation or parallelism.
+- Review-heavy workflows use native `codex review` or `codex exec review` semantics instead of Claude-specific command frontmatter.
 
 ## Key design principles
 

--- a/drain-issues.md
+++ b/drain-issues.md
@@ -28,7 +28,7 @@ Arguments: **$ARGUMENTS**
 | `--no-merge` | false | Review PRs but don't auto-merge |
 | `--skip-review` | false | Create PRs without review/merge |
 | `--full-review` | false | Use Claude↔Codex review loop instead of basic review. Codex reviews each PR, Claude fixes issues, repeat until approved (max 15 iterations per PR). Much more thorough but slower (~5-15 min per PR). |
-| `--plan-review` | false | Two-pass Claude↔Codex plan refinement before coding. Pass A: Codex verifies diagnosis against real code (max 2 rounds). Pass B: Codex traces fix's side-effects through the codebase (max 3 rounds). Plan + review history committed to `.pair/` alongside the fix. Catches fix-breaks-something-else bugs that diagnosis-only review misses. |
+| `--plan-review` | false | Two-pass Claude↔Codex plan refinement before coding. Pass A: Codex verifies diagnosis against real code (max 2 rounds). Pass B: Codex traces fix's side-effects through the codebase (max 3 rounds). Plan + review history written to `.pair/` (gitignored, local to the worktree — never committed). Catches fix-breaks-something-else bugs that diagnosis-only review misses. |
 | `--get-all` | false | Process all open issues regardless of who is assigned. Without this flag, issues already assigned to someone else are skipped. |
 
 ---
@@ -324,7 +324,7 @@ Cite line numbers. No vague "consider edge cases".'
 
 ---
 
-After both passes, implement using the final `.pair/PLAN.md`. Commit `.pair/PLAN.md` and `.pair/REVIEW.md` alongside the fix so the pair-session is part of the PR record.
+After both passes, implement using the final `.pair/PLAN.md`. Do NOT commit `.pair/` — it is gitignored working-notes scratch and must stay local to the worktree. Never `git add -f` it. If the pair-session reasoning is worth preserving in the PR record, mirror a concise summary into the PR body instead.
 
 IMPORTANT - Return ONLY this minimal JSON (no other text):
 {\"issue\": XX, \"pr\": <number|null>, \"status\": \"success|failed\", \"error\": \"<short error if failed>\"}"

--- a/issue-pipeline.md
+++ b/issue-pipeline.md
@@ -295,7 +295,7 @@ If round reaches 3 → proceed to implement with the current (best) plan, but lo
 
 ---
 
-After both passes, implement using the final `.pair/PLAN.md`. Commit `.pair/PLAN.md` and `.pair/REVIEW.md` alongside the fix so the pair-session is part of the PR record.
+After both passes, implement using the final `.pair/PLAN.md`. Do NOT commit `.pair/` — it is gitignored working-notes scratch and must stay local to the worktree. Never `git add -f` it. If the pair-session reasoning is worth preserving in the PR record, mirror a concise summary into the PR body instead.
 
 GUARDRAILS:
 - NEVER push directly to master/main

--- a/skills/gh-workflow-suite/SKILL.md
+++ b/skills/gh-workflow-suite/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: gh-workflow-suite
+description: Codex-native port of the `claude-workflows` Git and GitHub automation suite. Use when the user asks to run or emulate `/commit`, `/pr`, `/fix-issue`, `/quick-fix`, `/create-issue`, `/review-pr`, `/review-changes`, `/scan-debt`, `/batch-issues`, `/drain-issues`, `/issue-pipeline`, or `/full-review`, or when they want an end-to-end issue-to-PR workflow, changelog-aware PR creation, backlog draining, or iterative Codex review loops.
+---
+
+# GH Workflow Suite
+
+## Overview
+
+Use this skill to preserve the intent of the original Claude slash commands while adapting them to Codex's actual primitives: skills, `exec_command`, `apply_patch`, `update_plan`, GitHub app tools, `gh`, and `codex review`.
+
+Read [references/porting-notes.md](references/porting-notes.md) at the start of the task, then open the matching workflow section in [references/workflows.md](references/workflows.md).
+
+## Workflow Selection
+
+- `/commit` -> `Commit`
+- `/pr` -> `Pull Request`
+- `/fix-issue` -> `Fix Issue`
+- `/quick-fix` -> `Quick Fix`
+- `/create-issue` -> `Create Issue`
+- `/review-pr` -> `Review PR`
+- `/review-changes` -> `Review Changes`
+- `/scan-debt` -> `Scan Debt`
+- `/batch-issues` -> `Batch Issues`
+- `/drain-issues` -> `Drain Issues`
+- `/issue-pipeline` -> `Issue Pipeline`
+- `/full-review` -> `Full Review`
+
+## Operating Rules
+
+- Prefer GitHub plugin tools for issue and PR metadata, diffs, labels, comments, and PR creation. Use `gh` for checkout, worktrees, branch management, pushes, and operations the plugin does not expose cleanly.
+- Prefer `codex review` or `codex exec review` for review-centric flows. To capture the final review text as a file, use `-o`/`--output-last-message` — but note it is supported by `codex exec review`, not by the bare `codex review` alias. Never pass `--full-auto`/`-s`/`-a` to either review form: the review subcommand rejects them and runs read-only + non-interactive by default.
+- Use `update_plan` for multi-step work. Pause for approval only when the user explicitly asked for a checkpoint or when risk or ambiguity is materially high.
+- Only use `spawn_agent` when the user explicitly asks for delegation, sub-agents, or parallel agent work. Otherwise run the workflow sequentially in the main thread.
+- Prefer `git worktree` for issue flows when the sandbox allows writing adjacent directories. If it does not, stay in the current workspace on a dedicated branch and call out the fallback.
+- Keep findings-first output for all review workflows, ordered by severity with concrete file references.
+
+## References
+
+- [references/porting-notes.md](references/porting-notes.md): Claude-to-Codex differences, tool mapping, and invocation examples.
+- [references/workflows.md](references/workflows.md): The workflow definitions to follow for each former slash command.

--- a/skills/gh-workflow-suite/agents/openai.yaml
+++ b/skills/gh-workflow-suite/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GH Workflow Suite"
+  short_description: "Ported GitHub workflows for Codex"
+  default_prompt: "Use $gh-workflow-suite to run the Codex-native equivalent of /fix-issue, /issue-pipeline, /review-pr, /review-changes, /scan-debt, or the other workflows in this repo."

--- a/skills/gh-workflow-suite/references/porting-notes.md
+++ b/skills/gh-workflow-suite/references/porting-notes.md
@@ -1,0 +1,53 @@
+# Porting Notes
+
+## Purpose
+
+This skill ports the original `claude-workflows` command set to Codex without pretending there is a one-to-one slash-command runtime. In this local Codex install, skills are the reusable discovery mechanism.
+
+## Core Differences
+
+- Claude slash-command frontmatter such as `allowed-tools`, `argument-hint`, and inline `!` shell snippets do not map directly. Preserve behavior, not syntax.
+- Codex does not expose a local slash-command directory in this install. Invoke the port as a skill, for example: `Use $gh-workflow-suite to run the /fix-issue flow for issue #42.`
+- Claude `Task` maps to `spawn_agent`, but only when the user explicitly requested delegation, sub-agents, or parallel agent work.
+- Claude plan mode maps to `update_plan` plus normal commentary. Do not stop for plan approval unless the user asked for it or the risk is high.
+- Claude `Read`, `Grep`, and `Glob` map to `exec_command` and `multi_tool_use.parallel`, typically using `rg`, `sed`, `git`, and other local CLI tools.
+- Claude `Edit` and `Write` map to `apply_patch` for manual edits.
+
+## Tool Mapping
+
+| Claude workflow concept | Codex-native equivalent |
+| --- | --- |
+| Slash command | Explicit skill invocation or natural-language request |
+| `Bash(...)` | `exec_command` |
+| `Read` / `Grep` / `Glob` | `exec_command` with `rg`, `sed`, `find`, `git`; parallelize independent reads with `multi_tool_use.parallel` |
+| `Edit` / `Write` | `apply_patch` |
+| `Task` subagent | `spawn_agent` only with explicit user permission |
+| Plan mode | `update_plan` and concise commentary |
+| Claude self-review | `codex review` or findings-first manual review |
+| Codex subprocess parsing | Prefer `codex exec ... -o <file>` over JSONL parsing |
+
+## GitHub Guidance
+
+- Prefer the GitHub plugin for fetching issues, PR metadata, diffs, comments, and creating PRs.
+- Prefer `gh` for repo-local operations: `gh pr checkout`, `gh issue view`, `gh pr diff`, branch pushes, and any flow that is already shell-centric.
+- If the user asks to fix CI specifically, prefer the existing `github:gh-fix-ci` skill instead of reproducing that logic here.
+- If the user asks to address review comments on an existing PR, prefer `github:gh-address-comments` when it covers the task.
+
+## Review Guidance
+
+- Use `codex review --base origin/<default-branch>` for branch reviews and `codex review --uncommitted` for local changes when a fresh review pass is useful.
+- Do not depend exclusively on `[P1]`/`[P2]`/`[P3]` tags. If the review output uses those tags, respect them. If it uses prose severity, treat any clearly blocking or high-severity finding as blocking.
+- Keep review responses findings-first with file references.
+
+## Worktree Guidance
+
+- Prefer worktrees for issue workflows because they preserve isolation.
+- If the sandbox or workspace policy prevents writing sibling directories, fall back to a dedicated branch in the current workspace and state that the workflow is using the fallback.
+
+## Invocation Examples
+
+- `Use $gh-workflow-suite to run the /commit flow for the current changes.`
+- `Use $gh-workflow-suite to do the /fix-issue workflow for issue #42.`
+- `Use $gh-workflow-suite to emulate /issue-pipeline for "add volatility regime detection" with --plan-review.`
+- `Use $gh-workflow-suite to run /review-pr for PR #123.`
+- `Use $gh-workflow-suite to perform /drain-issues label:bug with --dry-run.`

--- a/skills/gh-workflow-suite/references/workflows.md
+++ b/skills/gh-workflow-suite/references/workflows.md
@@ -1,0 +1,149 @@
+# Workflows
+
+## Shared Guardrails
+
+- Stay off the default branch for commit and PR creation flows.
+- Read the full GitHub issue thread, not just the top-level body, before implementing fixes.
+- Prefer root-cause fixes over surface-level patches.
+- Write or update a failing test first for bug-fix workflows when the project has tests.
+- Run targeted verification plus the broadest practical test and lint/typecheck commands before committing.
+- Stage specific files instead of broad `git add .` or `git add -A` when avoidable.
+- Update the repo-root `CHANGELOG.md` when the repository uses one and the change is user-facing.
+
+## Commit
+
+Use for the former `/commit` flow.
+
+1. Verify the current branch is not the default branch.
+2. Inspect staged, unstaged, and untracked changes.
+3. Stage the intended files if the user asked for a commit but nothing is staged yet.
+4. Propose a conventional commit message based on the actual diff.
+5. Ask before running `git commit` unless the user clearly asked for an immediate commit.
+
+## Pull Request
+
+Use for the former `/pr` flow.
+
+1. Confirm the branch is not the default branch and the working tree is ready.
+2. Fetch and rebase or merge the default branch as appropriate for the repo.
+3. Run the `Review Changes` workflow or `codex review --base origin/<default-branch>` before opening the PR.
+4. Draft a structured PR body covering summary, problem, solution, testing, impact, and breaking changes.
+5. Update `CHANGELOG.md` if appropriate.
+6. Push the branch and create the PR with the GitHub plugin or `gh pr create`.
+
+## Fix Issue
+
+Use for the former `/fix-issue` flow.
+
+1. Fetch the issue body, labels, and all comments.
+2. Prefer creating a worktree from the default branch. If sandbox rules block that, create a dedicated branch in the current workspace instead.
+3. Investigate the root cause before writing code.
+4. Publish a short plan with `update_plan`. Pause only if the user requested a checkpoint or the change is risky or ambiguous.
+5. Write a failing test first when the project supports it.
+6. Implement the smallest fix that addresses the root cause.
+7. Run the new test, broader tests, and lint or typecheck commands.
+8. Self-review with `Review Changes` or `codex review`.
+9. Update changelog, commit, push, and create a PR linked to the issue.
+
+## Quick Fix
+
+Use for the former `/quick-fix` flow.
+
+1. Follow the `Fix Issue` workflow with fewer checkpoints.
+2. Proceed autonomously after a brief plan unless ambiguity is material.
+3. Retry verification once or twice if failures look mechanical rather than conceptual.
+4. Stop and surface the blocker if the issue remains unclear or verification keeps failing.
+
+## Create Issue
+
+Use for the former `/create-issue` flow.
+
+1. Infer the issue type from the request: bug, feature, enhancement, task, or documentation.
+2. Draft a tight title, description, context, reproduction steps if relevant, and acceptance criteria.
+3. Verify labels before using them.
+4. Ask for confirmation before creating the issue unless the user explicitly asked you to create it now.
+5. Create the issue with the GitHub plugin or `gh issue create`.
+
+## Review PR
+
+Use for the former `/review-pr` flow.
+
+1. Fetch PR metadata, commits, changed files, diff, and CI status.
+2. Determine whether the PR belongs to the authenticated user. If so, comment instead of approving or requesting changes.
+3. Review for changelog alignment, debug code, secrets, breaking changes, test coverage, PR size, and merge safety.
+4. Return findings first with severity and file references.
+5. If the user asked you to interact on GitHub, submit a review comment, approval, or change request using the GitHub plugin or `gh`.
+
+## Review Changes
+
+Use for the former `/review-changes` flow.
+
+1. Determine the diff range against the merge base with the default branch.
+2. Inspect changed files for breaking contracts, removed exports, changed signatures, async or sync changes, schema changes, and risky surface-level fixes.
+3. Search call sites and related code paths with `rg`.
+4. Return a findings-first review with severity, file references, and concrete fixes.
+
+## Scan Debt
+
+Use for the former `/scan-debt` flow.
+
+1. Determine the target scope: whole repo or a specific path.
+2. Scan for TODO/FIXME/HACK markers, type escapes, debug artifacts, tracked secrets, oversized files, and missing tests.
+3. Run dependency audit commands that make sense for the detected ecosystem, such as `npm audit` or `cargo audit`, when available.
+4. Summarize by priority with the highest-risk findings first.
+5. Offer issue creation only if the user wants the findings turned into GitHub issues.
+
+## Batch Issues
+
+Use for the former `/batch-issues` flow.
+
+Interpret literal carry-over options like `label:bug`, `10-15`, `assignee:@me`, and `all-open` as filters.
+
+If the user explicitly requested parallel or delegated execution:
+
+1. Gather the issue list and confirm the intended subset if the scope is broad.
+2. Spawn at most three workers with disjoint issue ownership and isolated branches or worktrees.
+3. Have each worker follow the `Fix Issue` or `Quick Fix` workflow for its assigned issue.
+4. Aggregate PR numbers, failures, and cleanup notes in the main thread.
+
+If the user did not explicitly request delegation:
+
+1. Explain that the Codex port runs this workflow sequentially by default.
+2. Process the selected issues one by one in the main thread.
+
+## Drain Issues
+
+Use for the former `/drain-issues` flow.
+
+Interpret former flags such as `--dry-run`, `--max-parallel=N`, `--skip-review`, `--no-merge`, `--full-review`, `--plan-review`, and `--get-all` as user options when they appear literally.
+
+1. Fetch open issues with assignment data and any label filter.
+2. Skip issues assigned to someone else unless the user explicitly asked for all issues.
+3. Analyze blocking dependencies, distinguishing true blockers from umbrella or tracking references.
+4. Build waves of independent issues.
+5. If `--dry-run` is present, stop after showing the wave plan.
+6. If the user explicitly requested delegation, process each wave with up to the allowed number of workers. Otherwise process each wave sequentially in the main thread.
+7. Review, merge, and clean up according to `--skip-review`, `--no-merge`, and `--full-review`.
+
+## Issue Pipeline
+
+Use for the former `/issue-pipeline` flow.
+
+Interpret a bare number as an existing issue and free text as a request to create a new issue first.
+
+1. If the request is text, run the `Create Issue` workflow first.
+2. Sharpen the problem statement locally before implementation. Only shell out to a fresh `codex exec` context if a clean second pass is materially useful.
+3. Follow the `Fix Issue` workflow for the resulting issue.
+4. If `--plan-review` is present, do an explicit plan-review pass before coding. This can be a local refinement pass or a fresh `codex exec` call if a separate context helps.
+5. After implementation, run the `Review PR` or `Full Review` workflow depending on whether `--full-review` is present.
+
+## Full Review
+
+Use for the former `/full-review` flow.
+
+1. Fetch the PR metadata, check out the PR branch, and identify the base branch.
+2. Run a fresh Codex review pass, preferably with a command like `codex exec review --base origin/<base-branch> --title "<pr-title>" --ephemeral -o /tmp/codex-review.txt`. (Do NOT pass `--full-auto`/`-s`/`-a` to `codex exec review` — the review subcommand rejects them; it runs read-only and non-interactive by default. `-o`/`--output-last-message` is supported by `codex exec review`, but not by the bare `codex review` alias.)
+3. Treat clearly blocking or high-severity findings as must-fix. If the output includes `[P1]` or `[P2]`, use those tags directly.
+4. Fix only files that are already part of the PR scope unless an adjacent test or config change is necessary.
+5. Commit and push each iteration, keeping a short iteration history so repeated review passes do not revisit closed issues.
+6. Stop when the review is effectively clean or when the maximum iteration limit is reached.


### PR DESCRIPTION
## Summary

Adds a Codex-native port of the Claude workflow suite as the `gh-workflow-suite` skill, since the local Codex install doesn't expose a comparable slash-command directory. Each `/command` is adapted to Codex primitives (`gh`, `codex exec`, `codex review`/`codex exec review`, `apply_patch`, `update_plan`).

## Contents

- **`skills/gh-workflow-suite/`** — `SKILL.md`, `references/workflows.md`, `references/porting-notes.md`, `agents/openai.yaml`
- **README** — Codex Port section + usage prompts
- **CHANGELOG** — `Added` entry

## Correctness fixes folded in

- Codex invocations use flags that actually parse on **codex-cli 0.136.0**: removed `--full-auto` from `codex exec review` (it errors there), and documented that `-o`/`--output-last-message` works on `codex exec review` but not the bare `codex review` alias. (Same class of bug fixed in the Claude commands in #17.)
- **`.pair/` convention made consistent**: the docs say `.pair/` is gitignored scratch — this PR actually adds `.pair/` to `.gitignore` and aligns the `/drain-issues` + `/issue-pipeline` docs to "never commit `.pair/`".

Fixes #18
