### PR TITLE
perf(workflows): replace Workflow fan-out with inline plan-adherence verification

### DIFF
--- a/drain-issues.md
+++ b/drain-issues.md
@@ -1,7 +1,7 @@
 ---
-allowed-tools: Bash(git:*), Bash(gh:*), Task, Workflow
+allowed-tools: Bash(git:*), Bash(gh:*), Task
 argument-hint: [label:filter] [--max-parallel=N] [--dry-run] [--get-all] [--no-plan-review] [--basic-review] [--no-verify]
-description: Autonomous issue processor - analyzes dependencies, batches independent issues, repeats until done. ALL quality gates ON by default: two-pass Codex plan refinement before coding, plan-adherence verification (Workflow drift report) after coding, and the Claude↔Codex full-review loop before merge. Opt out with --no-plan-review / --no-verify / --basic-review.
+description: Autonomous issue processor - analyzes dependencies, batches independent issues, repeats until done. ALL quality gates ON by default: two-pass Codex plan refinement before coding, plan-adherence verification (inline drift report) after coding, and the Claude↔Codex full-review loop before merge. Opt out with --no-plan-review / --no-verify / --basic-review.
 ---
 
 # Autonomous Issue Drainer
@@ -29,7 +29,7 @@ Arguments: **$ARGUMENTS**
 | `--skip-review` | false | Skip Phase 6 review/merge entirely (PRs left open) |
 | `--basic-review` | false | Use fast basic diff review (~1-2 min per PR) instead of the DEFAULT Claude↔Codex review loop (Codex reviews each PR, Claude fixes issues, repeat until approved, max 15 iterations per PR, ~5-15 min). |
 | `--no-plan-review` | false | Skip the DEFAULT two-pass Claude↔Codex plan refinement before coding. Pass A: Codex verifies diagnosis against real code (max 2 rounds). Pass B: Codex traces fix's side-effects through the codebase (max 3 rounds). Plan + review history written to `.pair/` (gitignored, local to the worktree — never committed). Catches fix-breaks-something-else bugs that diagnosis-only review misses. |
-| `--no-verify` | false | Skip the DEFAULT Phase 5.5 plan-adherence verification: a Workflow fans out one verifier per plan claim, adversarially confirms divergences, reverse-traces unplanned diff changes, and posts an Implementation Report on each PR. PLAN_NOT_MET PRs are blocked from auto-merge. |
+| `--no-verify` | false | Skip the DEFAULT Phase 5.5 plan-adherence verification: an inline pass checks each plan claim against the PR diff, reverse-traces unplanned changes, and posts an Implementation Report on each PR. PLAN_NOT_MET PRs are blocked from auto-merge. |
 | `--get-all` | false | Process all open issues regardless of who is assigned. Without this flag, issues already assigned to someone else are skipped. |
 
 The legacy `--plan-review` / `--full-review` flags are accepted but redundant — they are now the default behavior. Fastest escape hatch (roughly the old default): `--no-plan-review --no-verify --basic-review`.
@@ -382,7 +382,9 @@ Failed: #41 - Test failures in utils.test.ts
 
 Skip only if `--no-verify` was passed.
 
-This phase asks a different question than review: not "is the code good?" but **"is the code what the plan said we'd build?"** It runs once per wave, in the **main conversation** (NOT inside fix subagents — Task subagents must not nest Workflow calls), after PRs are created (Phase 5) and BEFORE review/merge (Phase 6).
+This phase asks a different question than review: not "is the code good?" but **"is the code what the plan said we'd build?"** It runs once per wave, **inline in the main conversation** — no subagents, no fan-out — after PRs are created (Phase 5) and BEFORE review/merge (Phase 6).
+
+**Cost rule: budget ONE `gh pr diff` per PR plus targeted file reads.** Do not spawn agents or workflows here, and do not re-review code quality — that is Phase 6's job.
 
 **CRITICAL: do not remove any worktree before this phase completes** — verifiers read `.pair/PLAN.md` from the worktrees (gitignored, exists only there).
 
@@ -393,100 +395,25 @@ For each successful PR in the wave (from the subagent JSON: issue, pr, worktree)
 2. Parse it into discrete claims: Acceptance Criteria checkboxes (type `ac`), Files & Line Numbers entries (`file`), Test Plan items (`test`), Side-Effects Trace invariants (`side-effect`). Assign ids like `ac1`, `f1`, `t1`, `s1`.
 3. **Fallback:** if PLAN.md is missing or its ACs are generic boilerplate, use the issue's own acceptance criteria as the contract and note it in that PR's report header: `> Verified against issue acceptance criteria — no implementation plan existed.`
 
-### Step 2 — Run ONE verification workflow for the whole wave
+### Step 2 — Verify each PR inline, one at a time
 
-Call the **Workflow tool** with the script below, passing `args: { prs: [{ pr, issue, worktree, claims: [{id, type, text}] }, ...] }`. Claims are flattened across PRs so verification of one PR doesn't wait on another; adversarial confirm runs only on DIVERGED/MISSING findings; one reverse-trace agent per PR surfaces unplanned changes.
+For each PR in the wave:
 
-```js
-export const meta = {
-  name: 'wave-plan-adherence',
-  description: 'Verify each wave PR against its PLAN.md and report drift',
-  phases: [
-    { title: 'Verify', detail: 'one agent per plan claim, all PRs flattened' },
-    { title: 'Confirm', detail: 'adversarial check on divergences only' },
-    { title: 'Trace', detail: 'one reverse-trace agent per PR' },
-  ],
-}
-const VERDICT = {
-  type: 'object',
-  properties: {
-    status: { type: 'string', enum: ['MATCHED', 'DIVERGED', 'MISSING', 'UNVERIFIABLE'] },
-    evidence: { type: 'string', description: 'file:line citations' },
-    divergence: { type: 'string', description: 'how the implementation differs (empty if MATCHED)' },
-  },
-  required: ['status', 'evidence'],
-}
-const REFUTE = {
-  type: 'object',
-  properties: { refuted: { type: 'boolean' }, reason: { type: 'string' } },
-  required: ['refuted', 'reason'],
-}
-const UNPLANNED = {
-  type: 'object',
-  properties: {
-    changes: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: { location: { type: 'string' }, description: { type: 'string' } },
-        required: ['location', 'description'],
-      },
-    },
-  },
-  required: ['changes'],
-}
-const flat = args.prs.flatMap(p =>
-  p.claims.map(c => ({ ...c, pr: p.pr, issue: p.issue, worktree: p.worktree })))
+1. Read its diff once: `gh pr diff <pr>`. That single read is the evidence base for every claim on that PR.
+2. Walk the claim list and classify each claim:
+   - **MATCHED** — implemented as the plan stated
+   - **DIVERGED** — implemented, but differently than planned; note exactly how
+   - **MISSING** — not implemented at all
+   - **UNVERIFIABLE** — cannot be determined from the code
+3. Cite `file:line` evidence. Only open a worktree file when the diff alone can't settle a claim — read the specific region, not the whole file.
+4. Before marking a claim DIVERGED or MISSING, re-check the diff for the change under a different name or location. A rename or a move is not a miss.
+5. Reverse-trace in the same pass: note any hunk that maps to no claim — those are the unplanned changes. Collapse mechanical noise (imports, formatting, lockfiles) into one line.
 
-const verified = await pipeline(flat,
-  c => agent(`Verify this implementation-plan claim against the ACTUAL code.
-
-CLAIM (${c.type}): ${c.text}
-
-Worktree with the implementation: ${c.worktree} — read the real files there.
-PR diff: run \`gh pr diff ${c.pr}\`.
-
-Classify as exactly one of:
-- MATCHED: implemented as the plan stated
-- DIVERGED: implemented, but differently than planned — describe exactly how in 'divergence'
-- MISSING: not implemented at all
-- UNVERIFIABLE: cannot be determined from the code
-
-Cite file:line evidence for whatever you conclude.`,
-    { label: `verify:pr${c.pr}:${c.id}`, phase: 'Verify', schema: VERDICT }),
-  (v, c) => (!v || v.status === 'MATCHED' || v.status === 'UNVERIFIABLE')
-    ? ({ claim: c, verdict: v, confirmed: true })
-    : parallel([1, 2].map(i => () =>
-        agent(`A verifier reviewed PR #${c.pr} (worktree: ${c.worktree}) and reported:
-
-CLAIM: ${c.text}
-FINDING: ${v.status} — ${v.divergence || v.evidence}
-
-Your job (independent perspective ${i}): try to REFUTE this finding. Read the actual code and prove the claim WAS implemented as planned. Set refuted=true only with file:line proof; if you cannot refute after honest search, set refuted=false.`,
-          { label: `confirm:pr${c.pr}:${c.id}`, phase: 'Confirm', schema: REFUTE })))
-        .then(votes => ({
-          claim: c, verdict: v,
-          confirmed: votes.filter(Boolean).filter(x => !x.refuted).length >= 1,
-        }))
-)
-
-const traces = await pipeline(args.prs,
-  p => agent(`Read the full diff of PR #${p.pr} (run \`gh pr diff ${p.pr}\`).
-
-PLAN CLAIMS:
-${p.claims.map(c => `- [${c.id}] ${c.text}`).join('\n')}
-
-For each diff hunk, map it to a claim id. Return ONLY the changes that map to NO claim — these are unplanned changes. Group mechanical noise (imports, formatting, lockfiles) into a single entry.`,
-    { label: `trace:pr${p.pr}`, phase: 'Trace', schema: UNPLANNED })
-    .then(u => ({ pr: p.pr, unplanned: u ? u.changes : [] }))
-)
-
-return { verified: verified.filter(Boolean), traces: traces.filter(Boolean) }
-```
+Then move to the next PR. Nothing here runs in parallel, and nothing spawns an agent.
 
 ### Step 3 — Per-PR Implementation Report
 
-Group the workflow's return value by PR and post one report per PR (`gh pr comment <pr> --body "<report>"`):
+Post one report per PR (`gh pr comment <pr> --body "<report>"`):
 
 ```markdown
 ## Implementation Report — PR #<pr> (Issue #<n>)
@@ -503,12 +430,12 @@ Group the workflow's return value by PR and post one report per PR (`gh pr comme
 **Summary:** N as planned · N diverged · N missing · N unplanned
 ```
 
-Status mapping: `MATCHED` → ✅ · confirmed `DIVERGED` → 🔀 · confirmed `MISSING` → ❌ · `UNVERIFIABLE` → ⚠️. A DIVERGED/MISSING finding the Confirm step refuted (`confirmed: false`) is reported as ✅.
+Status mapping: `MATCHED` → ✅ · `DIVERGED` → 🔀 · `MISSING` → ❌ · `UNVERIFIABLE` → ⚠️.
 
 ### Step 4 — Record per-PR verdict (gates Phase 6)
 
-- **PLAN_MET:** no confirmed ❌ on any `ac` or `test` claim.
-- **PLAN_NOT_MET:** at least one confirmed ❌ on an `ac` or `test` claim. Attempt ONE fix cycle: apply the missing piece in the worktree, commit, push, re-verify just the failed claims (re-run the workflow with only those claims). If still failing → the PR is **blocked from auto-merge** in Phase 6; leave it open with the report comment as the record and move on.
+- **PLAN_MET:** no ❌ on any `ac` or `test` claim.
+- **PLAN_NOT_MET:** at least one ❌ on an `ac` or `test` claim. Attempt ONE fix cycle: apply the missing piece in the worktree, commit, push, re-verify **only the failed claims**. If still failing → the PR is **blocked from auto-merge** in Phase 6; leave it open with the report comment as the record and move on.
 
 ```
 Wave 1 Verification Summary:

--- a/issue-pipeline.md
+++ b/issue-pipeline.md
@@ -1,7 +1,7 @@
 ---
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(grep:*), Bash(find:*), Bash(cat:*), Bash(npm:*), Bash(cargo:*), Bash(pnpm:*), Task, Workflow
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(grep:*), Bash(find:*), Bash(cat:*), Bash(npm:*), Bash(cargo:*), Bash(pnpm:*), Task
 argument-hint: <issue-description OR issue-number> [--no-plan-review] [--basic-review] [--no-verify]
-description: Full pipeline: create issue (if needed), plan-review it (Claude↔Codex two-pass), fix it, verify implementation against plan (Workflow drift report), create PR, full Claude↔Codex review. ALL quality gates ON by default — use --no-plan-review / --basic-review / --no-verify to opt out.
+description: Full pipeline: create issue (if needed), plan-review it (Claude↔Codex two-pass), fix it, verify implementation against plan (inline drift report), create PR, full Claude↔Codex review. ALL quality gates ON by default — use --no-plan-review / --basic-review / --no-verify to opt out.
 ---
 
 # Issue Pipeline - Automated Flow
@@ -32,7 +32,7 @@ Determine the mode:
 | Gate | Default | Opt-out flag |
 |------|---------|--------------|
 | Plan Review Loop (Codex two-pass, before coding) | ON | `--no-plan-review` |
-| Verification Phase (plan-adherence Workflow + Implementation Report) | ON | `--no-verify` |
+| Verification Phase (inline plan-adherence + Implementation Report) | ON | `--no-verify` |
 | Full Claude↔Codex review loop on the PR | ON | `--basic-review` (falls back to fast diff review) |
 
 The legacy `--plan-review` / `--full-review` flags are accepted but redundant — they are now the default behavior.
@@ -324,7 +324,9 @@ Work autonomously. Make reasonable decisions. Only ask if truly blocked."
 
 Runs after the Fix Phase, before the Review Phase. Skip only if `--no-verify` was passed.
 
-The review loop asks "is the code good?". This phase asks a different question: **"is the code what we said we'd build?"** It verifies the implementation claim-by-claim against `.pair/PLAN.md` using a fan-out Workflow, then produces an **Implementation Report**: what was implemented as planned, what diverged, what's missing, and what changed without being in the plan.
+The review loop asks "is the code good?". This phase asks a different question: **"is the code what we said we'd build?"** It verifies the implementation claim-by-claim against `.pair/PLAN.md` **inline, in the main conversation** — no subagents, no fan-out — then produces an **Implementation Report**: what was implemented as planned, what diverged, what's missing, and what changed without being in the plan.
+
+**Cost rule: this phase is ONE diff read plus targeted file reads.** Do not spawn agents, do not launch workflows, do not re-review the code for quality — that is the Review Phase's job.
 
 ### Step 1 — Gather the contract
 
@@ -340,100 +342,21 @@ Extract one claim per:
 - Test Plan item → type `test` (ids `t1`, ...)
 - Side-Effects Trace invariant → type `side-effect` (ids `s1`, ...)
 
-### Step 3 — Run the verification workflow
+### Step 3 — Verify inline against the diff
 
-Call the **Workflow tool** with the script below, passing `args: { worktree: "<abs path>", pr: <number>, claims: [{id, type, text}, ...] }`. Design notes: one verifier per claim; adversarial confirm runs ONLY on bad news (DIVERGED/MISSING) so the report doesn't cry wolf; one reverse-trace agent maps diff hunks back to claims to surface unplanned changes.
-
-```js
-export const meta = {
-  name: 'plan-adherence',
-  description: 'Verify implementation against PLAN.md claims and produce drift report',
-  phases: [
-    { title: 'Verify', detail: 'one agent per plan claim' },
-    { title: 'Confirm', detail: 'adversarial check on divergences only' },
-    { title: 'Trace', detail: 'map diff hunks back to claims' },
-  ],
-}
-const VERDICT = {
-  type: 'object',
-  properties: {
-    status: { type: 'string', enum: ['MATCHED', 'DIVERGED', 'MISSING', 'UNVERIFIABLE'] },
-    evidence: { type: 'string', description: 'file:line citations' },
-    divergence: { type: 'string', description: 'how the implementation differs from the claim (empty if MATCHED)' },
-  },
-  required: ['status', 'evidence'],
-}
-const REFUTE = {
-  type: 'object',
-  properties: { refuted: { type: 'boolean' }, reason: { type: 'string' } },
-  required: ['refuted', 'reason'],
-}
-const UNPLANNED = {
-  type: 'object',
-  properties: {
-    changes: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: { location: { type: 'string' }, description: { type: 'string' } },
-        required: ['location', 'description'],
-      },
-    },
-  },
-  required: ['changes'],
-}
-const { worktree, pr, claims } = args
-const claimList = claims.map(c => `- [${c.id}] (${c.type}) ${c.text}`).join('\n')
-
-const verified = await pipeline(claims,
-  c => agent(`Verify this implementation-plan claim against the ACTUAL code.
-
-CLAIM (${c.type}): ${c.text}
-
-Worktree with the implementation: ${worktree} — read the real files there.
-PR diff: run \`gh pr diff ${pr}\`.
-
-Classify as exactly one of:
-- MATCHED: implemented as the plan stated
-- DIVERGED: implemented, but differently than planned — describe exactly how in 'divergence'
-- MISSING: not implemented at all
-- UNVERIFIABLE: cannot be determined from the code
-
-Cite file:line evidence for whatever you conclude.`,
-    { label: `verify:${c.id}`, phase: 'Verify', schema: VERDICT }),
-  (v, c) => (!v || v.status === 'MATCHED' || v.status === 'UNVERIFIABLE')
-    ? ({ claim: c, verdict: v, confirmed: true })
-    : parallel([1, 2].map(i => () =>
-        agent(`A verifier reviewed PR #${pr} (worktree: ${worktree}) and reported:
-
-CLAIM: ${c.text}
-FINDING: ${v.status} — ${v.divergence || v.evidence}
-
-Your job (independent perspective ${i}): try to REFUTE this finding. Read the actual code and prove the claim WAS implemented as planned. Set refuted=true only with file:line proof; if you cannot refute after honest search, set refuted=false.`,
-          { label: `confirm:${c.id}`, phase: 'Confirm', schema: REFUTE })))
-        .then(votes => ({
-          claim: c, verdict: v,
-          confirmed: votes.filter(Boolean).filter(x => !x.refuted).length >= 1,
-        }))
-)
-
-const unplanned = await agent(`Read the full diff of PR #${pr} (run \`gh pr diff ${pr}\`).
-
-PLAN CLAIMS:
-${claimList}
-
-For each diff hunk, map it to a claim id. Return ONLY the changes that map to NO claim — these are unplanned changes. Group mechanical noise (imports, formatting, lockfiles) into a single entry.`,
-  { label: 'reverse-trace', phase: 'Trace', schema: UNPLANNED })
-
-return {
-  verified: verified.filter(Boolean),
-  unplanned: unplanned ? unplanned.changes : [],
-}
-```
+1. Read the diff once: `gh pr diff <pr>`. That single read is the evidence base for every claim.
+2. Walk the claim list top to bottom and classify each one:
+   - **MATCHED** — implemented as the plan stated
+   - **DIVERGED** — implemented, but differently than planned; note exactly how
+   - **MISSING** — not implemented at all
+   - **UNVERIFIABLE** — cannot be determined from the code
+3. Cite `file:line` evidence for each verdict. Only open a file from the worktree when the diff alone can't settle a claim (e.g. the claim is about behavior in unchanged surrounding code) — read the specific region, not the whole file.
+4. Before marking a claim DIVERGED or MISSING, re-check the diff for the change under a different name or location — a rename or a move is not a miss. That single re-check replaces the old adversarial confirm step.
+5. Reverse-trace in the same pass: as you read hunks, note any hunk that maps to no claim. Those are the unplanned changes. Collapse mechanical noise (imports, formatting, lockfiles) into one line.
 
 ### Step 4 — Render and post the Implementation Report
 
-From the workflow's return value, build:
+From your inline verdicts, build:
 
 ```markdown
 ## Implementation Report — PR #<pr> (Issue #<n>)
@@ -450,14 +373,14 @@ From the workflow's return value, build:
 **Summary:** N as planned · N diverged · N missing · N unplanned
 ```
 
-Status mapping: `MATCHED` → ✅ · confirmed `DIVERGED` → 🔀 · confirmed `MISSING` → ❌ · `UNVERIFIABLE` → ⚠️. A DIVERGED/MISSING finding that the Confirm step refuted (`confirmed: false`) is reported as ✅ — the verifier was wrong, note it briefly.
+Status mapping: `MATCHED` → ✅ · `DIVERGED` → 🔀 · `MISSING` → ❌ · `UNVERIFIABLE` → ⚠️.
 
 Post it on the PR: `gh pr comment <pr> --body "<report>"` — this is the durable record of plan-vs-reality.
 
 ### Step 5 — Decision
 
-- **Any confirmed ❌ on an `ac` or `test` claim** → the implementation does not meet its own contract. Fix it in the worktree (apply the missing piece, commit, push), then re-run Steps 3–4. Max 2 verify-fix cycles; after that, proceed but mark the final pipeline status **NEEDS ATTENTION** and leave the report as the record.
-- **Confirmed 🔀** → non-blocking. The divergence is documented; if the implementation took a *better* path than the plan, fine — the point is it's no longer silent.
+- **Any ❌ on an `ac` or `test` claim** → the implementation does not meet its own contract. Fix it in the worktree (apply the missing piece, commit, push), then re-verify **only the failed claims** (not the whole list). Max 2 verify-fix cycles; after that, proceed but mark the final pipeline status **NEEDS ATTENTION** and leave the report as the record.
+- **🔀** → non-blocking. The divergence is documented; if the implementation took a *better* path than the plan, fine — the point is it's no longer silent.
 - **➕ unplanned changes** → non-blocking, but they are exactly what the Review Phase should scrutinize first — carry them into the review prompt.
 
 ---


### PR DESCRIPTION
## Problem

The plan-adherence phase in `/drain-issues` (Phase 5.5) and `/issue-pipeline` (Verification Phase) called the **Workflow tool** on every run:

- 1 agent per plan claim (ACs, files, tests, side-effects)
- 2 adversarial refuter agents per DIVERGED/MISSING finding
- 1 reverse-trace agent per PR

Every one of those agents re-read the same `gh pr diff`. Token cost and wall-clock scaled with claim count × PR count, for a check that is fundamentally one diff read.

## Change

Verification now runs **inline in the main conversation** — no subagents, no fan-out:

1. One `gh pr diff <pr>` per PR — the single evidence base for all its claims.
2. Claims classified top to bottom: MATCHED / DIVERGED / MISSING / UNVERIFIABLE with `file:line` evidence.
3. Worktree files opened only when the diff alone can't settle a claim, and only the relevant region.
4. Adversarial confirm replaced by a cheap self-check: re-scan the diff for the change under a different name or location before marking DIVERGED/MISSING — a rename or move is not a miss.
5. Reverse-trace of unplanned hunks folded into the same pass.
6. Explicit cost rule added to both files: no agents, no workflows, no code-quality re-review in this phase.

`Workflow` removed from `allowed-tools` in both commands.

## Unchanged

- Implementation Report format and status mapping (✅ / 🔀 / ❌ / ⚠️)
- `PLAN_MET` / `PLAN_NOT_MET` verdicts and the auto-merge block on `PLAN_NOT_MET`
- `--no-verify` opt-out
- **The Claude↔Codex plan-review and full-review loops — untouched, still ON by default**

Fix cycles now re-verify only the failed claims instead of the whole list.

## Scope

Only `drain-issues.md` and `issue-pipeline.md`. The Codex ports under `skills/gh-workflow-suite/references/` never used the Workflow tool — their adherence gates are already single Codex calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)