### PR TITLE
chore(workflows): route coder agents to opus instead of sonnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,9 @@ Types: `Added`, `Changed`, `Fixed`, `Removed`
   (plan-adherence verification + Implementation Report, Codex `[P1]`/`[P2]` triage,
   basic diff review, improvement-pass triage, merge decision) run on
   **claude-fable-5**, with a single automatic retry on **opus** if fable is
-  unavailable — never a downgrade to sonnet. All code — failing test,
+  unavailable — never a downgrade to a smaller model. All code — failing test,
   implementation, lint/test runs, changelog, commits, PRs, and applied review
-  fixes — is written by **claude-sonnet-5**. Consequences: the monolithic fix
+  fixes — is written by **claude-opus-5**. Consequences: the monolithic fix
   subagent is split into a planner agent and a coder agent (the coder returns
   `plan_rejected` with evidence instead of silently redesigning; one planner
   round-trip is allowed); reviewers emit fix lists but never edit files;

--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ Autonomous issue processor — analyzes dependencies between issues, batches ind
 | `--full-review` | `false` | Use Claude↔Codex review loop instead of basic review |
 | `--get-all` | `false` | Process all open issues regardless of assignment. By default, issues already assigned to someone else are skipped |
 | `--plan-model=M` | `fable` | Model for planner agents (`fable\|opus\|sonnet\|haiku`) |
-| `--code-model=M` | `sonnet` | Model for coder agents |
+| `--code-model=M` | `opus` | Model for coder agents |
 | `--review-model=M` | `fable` | Model for reviewer agents |
 
-**Model routing:** planning (root cause, `.pair/PLAN.md`, the single Codex plan review) and reviewing (plan-adherence verification, Codex finding triage, merge decision) run on **claude-fable-5**, falling back to **opus** if fable is unavailable. Code — tests, implementation, review fixes, commits, PRs — is written by **claude-sonnet-5**. A planner never implements and a reviewer never edits files; fixes always go back through a coder agent.
+**Model routing:** planning (root cause, `.pair/PLAN.md`, the single Codex plan review) and reviewing (plan-adherence verification, Codex finding triage, merge decision) run on **claude-fable-5**, falling back to **opus** if fable is unavailable. Code — tests, implementation, review fixes, commits, PRs — is written by **claude-opus-5**. A planner never implements and a reviewer never edits files; fixes always go back through a coder agent.
 
 **How it works:**
 1. Fetches all open issues (or filtered subset), skipping issues assigned to others (unless `--get-all`)
@@ -259,7 +259,7 @@ Autonomous issue processor — analyzes dependencies between issues, batches ind
 3. Groups independent issues into waves
 4. Presents wave plan and waits for confirmation
 5. **Assigns itself** to all issues in the wave before starting work (claims them)
-6. Processes each wave: planner agents (fable) write reviewed plans in worktrees → coder agents (sonnet) implement and open PRs → reviewer agents (fable) verify and triage → merge
+6. Processes each wave: planner agents (fable) write reviewed plans in worktrees → coder agents (opus) implement and open PRs → reviewer agents (fable) verify and triage → merge
 7. Cleans up worktrees after each merge
 8. Moves to next wave until all issues are processed
 9. Final summary with merged PRs, failed items, and cleanup commands
@@ -310,10 +310,10 @@ Full pipeline: create an issue (if needed), fix it, create a PR, and self-review
 | `--plan-review` | Redundant — one Codex plan review before implementation is the default (disable with `--no-plan-review`) |
 | `--full-review` | Claude↔Codex iterative review loop after implementation |
 | `--plan-model=M` | Model for the planner agent (default `fable`, fallback `opus`) |
-| `--code-model=M` | Model for the coder agent (default `sonnet`) |
+| `--code-model=M` | Model for the coder agent (default `opus`) |
 | `--review-model=M` | Model for reviewer agents (default `fable`, fallback `opus`) |
 
-**Model routing:** the plan and every review run on **claude-fable-5** (fallback **opus**); the code is written by **claude-sonnet-5**. Planner, coder, and reviewer are separate agents — the coder cannot silently redesign the plan (it must return `plan_rejected` instead), and the reviewer cannot edit files.
+**Model routing:** the plan and every review run on **claude-fable-5** (fallback **opus**); the code is written by **claude-opus-5**. Planner, coder, and reviewer are separate agents — the coder cannot silently redesign the plan (it must return `plan_rejected` instead), and the reviewer cannot edit files.
 
 **How it works:**
 1. **Detects mode:** number → fix existing issue; text → create new issue first
@@ -321,7 +321,7 @@ Full pipeline: create an issue (if needed), fix it, create a PR, and self-review
 3. **Sharpens the problem statement:** Codex pre-analyzes the issue and produces a precise problem statement (root cause hypothesis, affected files, edge cases, success criteria)
 4. **Planner agent (fable)**: creates worktree → investigates root cause → specifies the failing test → writes `.pair/PLAN.md`
 5. **Plan review** (default; `--no-plan-review` to skip): Codex reviews the plan **once** against the real code — diagnosis and fix side-effects in one pass → the planner absorbs the findings into `.pair/PLAN.md` → hand off. No re-review round
-6. **Coder agent (sonnet)**: writes the failing test → implements with minimal changes → runs tests + linter → updates changelog → commits → creates PR
+6. **Coder agent (opus)**: writes the failing test → implements with minimal changes → runs tests + linter → updates changelog → commits → creates PR
 7. **Reviewer agent (fable):** plan-adherence Implementation Report, then basic review (default) or Claude↔Codex loop (`--full-review`) — accepted fixes go back to a coder agent
 8. **Improvement passes:** up to 2 Codex-powered quality passes on the finished implementation (better abstractions, naming, edge cases)
 9. **Merges if safe**, or reports what needs attention

--- a/drain-issues.md
+++ b/drain-issues.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Bash(gh:*), Task
 argument-hint: [label:filter] [--max-parallel=N] [--dry-run] [--get-all] [--no-plan-review] [--basic-review] [--no-verify] [--plan-model=M] [--code-model=M] [--review-model=M]
-description: Autonomous issue processor - analyzes dependencies, batches independent issues, repeats until done. Plans and reviews run on claude-fable-5 (fallback opus), code is written by claude-sonnet-5. ALL quality gates ON by default: a single Codex plan review before coding, plan-adherence verification after coding, and the Claude↔Codex full-review loop before merge. Opt out with --no-plan-review / --no-verify / --basic-review.
+description: Autonomous issue processor - analyzes dependencies, batches independent issues, repeats until done. Plans and reviews run on claude-fable-5 (fallback opus), code is written by claude-opus-5. ALL quality gates ON by default: a single Codex plan review before coding, plan-adherence verification after coding, and the Claude↔Codex full-review loop before merge. Opt out with --no-plan-review / --no-verify / --basic-review.
 ---
 
 # Autonomous Issue Drainer
@@ -32,7 +32,7 @@ Arguments: **$ARGUMENTS**
 | `--no-verify` | false | Skip the DEFAULT Phase 5.5 plan-adherence verification: an inline pass checks each plan claim against the PR diff, reverse-traces unplanned changes, and posts an Implementation Report on each PR. PLAN_NOT_MET PRs are blocked from auto-merge. |
 | `--get-all` | false | Process all open issues regardless of who is assigned. Without this flag, issues already assigned to someone else are skipped. |
 | `--plan-model=M` | `fable` | Override the planner model (`fable\|opus\|sonnet\|haiku`). |
-| `--code-model=M` | `sonnet` | Override the coder model. |
+| `--code-model=M` | `opus` | Override the coder model. |
 | `--review-model=M` | `fable` | Override the reviewer model. |
 
 The legacy `--plan-review` / `--full-review` flags are accepted but redundant — they are now the default behavior. Fastest escape hatch (roughly the old default): `--no-plan-review --no-verify --basic-review`.
@@ -45,14 +45,14 @@ The legacy `--plan-review` / `--full-review` flags are accepted but redundant �
 |------|--------|-------|----------|
 | **Planner** | root-cause investigation, writing and revising `.pair/PLAN.md`, running the single Codex plan review and absorbing its findings | `fable` (claude-fable-5) | `opus` |
 | **Reviewer** | plan-adherence verification + Implementation Report, basic diff review, triaging Codex `[P1]`/`[P2]` findings, merge decisions | `fable` (claude-fable-5) | `opus` |
-| **Coder** | failing test, implementation, lint/test runs, CHANGELOG, commits, PR creation, applying fixes the reviewer decided to accept | `sonnet` (claude-sonnet-5) | — |
+| **Coder** | failing test, implementation, lint/test runs, CHANGELOG, commits, PR creation, applying fixes the reviewer decided to accept | `opus` (claude-opus-5) | — |
 
 Rules:
 
 1. **Every `Task` launch passes an explicit `model`.** Never inherit the session model — the routing above is the contract.
-2. **Fable fallback:** if a launch with `model: fable` fails because the model is unavailable/invalid/over quota, retry the *identical* launch once with `model: opus`, and log `⚠️ fable unavailable — <role> downgraded to opus`. Never fall back to `sonnet` for a planner or reviewer role: sonnet writes code, it does not plan or judge.
+2. **Fable fallback:** if a launch with `model: fable` fails because the model is unavailable/invalid/over quota, retry the *identical* launch once with `model: opus`, and log `⚠️ fable unavailable — <role> downgraded to opus`. Never downgrade a planner or reviewer to a smaller model (`sonnet`/`haiku`): planning and judging stay on fable or opus.
 3. **Coder agents never plan.** A coder receives a finished `.pair/PLAN.md` and implements it. If the coder believes the plan is wrong, it stops and returns `"status": "plan_rejected"` with the reason — the planner (fable) revises, then the coder resumes. Coders do not silently redesign.
-4. **Reviewers never write code.** A reviewer produces verdicts and a fix list; the fixes are applied by a coder agent (sonnet).
+4. **Reviewers never write code.** A reviewer produces verdicts and a fix list; the fixes are applied by a coder agent (opus).
 5. **Codex is unchanged** — it stays the external adversarial reviewer on its own default model. Never pass `--model` / `-c model=...` to Codex.
 6. The dependency/wave analysis in Phases 2–3 is planning work; when it is non-trivial (>10 issues or ambiguous chains), delegate it to a planner agent (`fable`) instead of doing it in the main loop.
 
@@ -350,12 +350,12 @@ Do NOT re-run Codex on the revised plan. Set `plan_review: "reviewed"` and hand 
 After the review is absorbed, the plan is final. Do NOT commit `.pair/` — it is gitignored working-notes scratch and must stay local to the worktree. Never `git add -f` it. If the pair-session reasoning is worth preserving in the PR record, mirror a concise summary into the PR body instead. `.pair/CONTEXT.md` follows the same rule: local to the worktree, never committed, and never deleted before Phase 5.5 has run. Then return the planner JSON above."
 ```
 
-### Step 4.2: Launch Coder Agents (model: `sonnet`)
+### Step 4.2: Launch Coder Agents (model: `opus`)
 
-For each issue whose planner returned `"status": "success"`, launch a **coder** Task agent with `model: "sonnet"`. Coders run in the planner's worktree and implement the approved plan — nothing more.
+For each issue whose planner returned `"status": "success"`, launch a **coder** Task agent with `model: "opus"`. Coders run in the planner's worktree and implement the approved plan — nothing more.
 
 ```
-Launch N parallel Task agents with model: "sonnet" (respecting --max-parallel):
+Launch N parallel Task agents with model: "opus" (respecting --max-parallel):
 
 Each coder receives:
 "Implement issue #XX from an already-reviewed plan. You are the CODER — the plan is the contract. Do not re-plan, do not redesign.
@@ -392,13 +392,13 @@ If wave has 4+ issues, split into sub-batches of 2. Each sub-batch runs plan →
 ```
 Wave 1 has 6 issues: [#12, #15, #22, #41, #28, #33]
 
-Sub-batch 1: plan #12, #15 in parallel (fable) → code #12, #15 in parallel (sonnet)
+Sub-batch 1: plan #12, #15 in parallel (fable) → code #12, #15 in parallel (opus)
   → Collect minimal results
 
-Sub-batch 2: plan #22, #41 (fable) → code #22, #41 (sonnet)
+Sub-batch 2: plan #22, #41 (fable) → code #22, #41 (opus)
   → Collect minimal results
 
-Sub-batch 3: plan #28, #33 (fable) → code #28, #33 (sonnet)
+Sub-batch 3: plan #28, #33 (fable) → code #28, #33 (opus)
   → Collect minimal results
 ```
 
@@ -496,7 +496,7 @@ Status mapping: `MATCHED` → ✅ · `DIVERGED` → 🔀 · `MISSING` → ❌ ·
 ### Step 4 — Record per-PR verdict (gates Phase 6)
 
 - **PLAN_MET:** no ❌ on any `ac` or `test` claim.
-- **PLAN_NOT_MET:** at least one ❌ on an `ac` or `test` claim. Attempt ONE fix cycle, respecting role separation: relaunch a **coder agent (`sonnet`)** in that worktree with the reviewer's `failed_claims[]` and instructions to apply only the missing pieces, commit and push; then relaunch the **reviewer agent (`fable`)** to re-verify **only the failed claims** (not the whole list). If still failing → the PR is **blocked from auto-merge** in Phase 6; leave it open with the report comment as the record and move on.
+- **PLAN_NOT_MET:** at least one ❌ on an `ac` or `test` claim. Attempt ONE fix cycle, respecting role separation: relaunch a **coder agent (`opus`)** in that worktree with the reviewer's `failed_claims[]` and instructions to apply only the missing pieces, commit and push; then relaunch the **reviewer agent (`fable`)** to re-verify **only the failed claims** (not the whole list). If still failing → the PR is **blocked from auto-merge** in Phase 6; leave it open with the report comment as the record and move on.
 
 ```
 Wave 1 Verification Summary:
@@ -518,8 +518,8 @@ Carry each PR's 🔀 and ➕ items into its Phase 6 review prompt — they are t
 
 There are two review modes. **Full review is the DEFAULT.** Use basic only if `--basic-review` was passed:
 
-- **Default (full review):** Uses the Claude↔Codex review loop — Codex reviews the PR, a **reviewer agent (`fable`)** triages the findings, a **coder agent (`sonnet`)** applies the accepted fixes, repeat until Codex approves (max 15 iterations). Thorough (~5-15 min per PR). Codex receives iteration history so it won't re-raise dismissed issues.
-- **`--basic-review` mode:** A **reviewer agent (`fable`)** reviews the diff for breaking changes, regressions, missing changelog, etc. Fast (~1-2 min per PR). Any fixes it asks for are applied by a coder agent (`sonnet`).
+- **Default (full review):** Uses the Claude↔Codex review loop — Codex reviews the PR, a **reviewer agent (`fable`)** triages the findings, a **coder agent (`opus`)** applies the accepted fixes, repeat until Codex approves (max 15 iterations). Thorough (~5-15 min per PR). Codex receives iteration history so it won't re-raise dismissed issues.
+- **`--basic-review` mode:** A **reviewer agent (`fable`)** reviews the diff for breaking changes, regressions, missing changelog, etc. Fast (~1-2 min per PR). Any fixes it asks for are applied by a coder agent (`opus`).
 
 **Verification gate (from Phase 5.5):** a PR marked PLAN_NOT_MET is NEVER auto-merged, regardless of review outcome — review it anyway (the findings are still useful), but leave it open with a comment pointing at the Implementation Report. Include each PR's 🔀 diverged and ➕ unplanned items in the review prompt.
 
@@ -536,7 +536,7 @@ for each PR in [#45, #46, #47]:
        Run the full Claude↔Codex review loop for this PR:
 
        a. Get the PR number
-       b. Execute the /full-review workflow inline, with roles split by model:
+       b. Execute the /full-review workflow inline, with roles split across separate agents:
           - Get PR info and checkout the branch
           - Initialize iteration history
           - Run Codex review via `codex exec review - --ephemeral --json` with the prompt piped on stdin (including iteration history context on rounds 2+); do NOT use `--full-auto`
@@ -546,7 +546,7 @@ for each PR in [#45, #46, #47]:
             (<file>:<line> — what to change — why). It does not edit files.
             The fix list must be SELF-CONTAINED: exact file, exact line/region, and the current
             code being changed — so the coder can act without re-reading to locate the site.
-          - CODER agent (model: "sonnet"): apply exactly the ACCEPTed fixes, run tests, commit, push.
+          - CODER agent (model: "opus"): apply exactly the ACCEPTed fixes, run tests, commit, push.
             Works from the fix list plus `.pair/CONTEXT.md`; does not re-explore the codebase.
             If a fix cannot be applied as specified, it returns the reason instead of improvising.
           - Update iteration history with outcomes (FIXED/DISMISSED) plus the dismissal reasons
@@ -554,14 +554,14 @@ for each PR in [#45, #46, #47]:
 
        c. Record the final result (approved / max iterations reached)
 
-       NOTE: the loop's fix-commit-push cycle is done by the sonnet coder; the
+       NOTE: the loop's fix-commit-push cycle is done by the opus coder; the
        accept/dismiss judgement is always fable's. After the loop completes, the PR is
        either clean (Codex approved) or has been iterated to convergence.
 
      If --basic-review mode:
        Launch a reviewer agent (model: "fable", fallback "opus") running /review-changes
        This checks: changelog, debug code, secrets, breaking changes, regressions
-       Any required fix is applied by a coder agent (model: "sonnet")
+       Any required fix is applied by a coder agent (model: "opus")
 
   2. IMMEDIATELY after review:
 
@@ -859,7 +859,7 @@ Run without --dry-run to process.
 # Trust the report, skip post-hoc verification only
 /drain-issues --no-verify
 
-# Model routing (defaults): plans + reviews on fable (fallback opus), code on sonnet
+# Model routing (defaults): plans + reviews on fable (fallback opus), code on opus
 /drain-issues
 
 # Force everything onto opus (e.g. fable is degraded)

--- a/issue-pipeline.md
+++ b/issue-pipeline.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(grep:*), Bash(find:*), Bash(cat:*), Bash(npm:*), Bash(cargo:*), Bash(pnpm:*), Task
 argument-hint: <issue-description OR issue-number> [--no-plan-review] [--basic-review] [--no-verify] [--plan-model=M] [--code-model=M] [--review-model=M]
-description: Full pipeline: create issue (if needed), plan-review it (one Codex pass), fix it, verify implementation against plan (drift report), create PR, full Claude↔Codex review. Plans and reviews run on claude-fable-5 (fallback opus), code is written by claude-sonnet-5. ALL quality gates ON by default — use --no-plan-review / --basic-review / --no-verify to opt out.
+description: Full pipeline: create issue (if needed), plan-review it (one Codex pass), fix it, verify implementation against plan (drift report), create PR, full Claude↔Codex review. Plans and reviews run on claude-fable-5 (fallback opus), code is written by claude-opus-5. ALL quality gates ON by default — use --no-plan-review / --basic-review / --no-verify to opt out.
 ---
 
 # Issue Pipeline - Automated Flow
@@ -45,14 +45,14 @@ The legacy `--plan-review` / `--full-review` flags are accepted but redundant �
 |------|--------|-------|----------|
 | **Planner** | root-cause investigation, writing and revising `.pair/PLAN.md`, running the single Codex plan review and absorbing its findings | `fable` (claude-fable-5) | `opus` |
 | **Reviewer** | Verification Phase + Implementation Report, basic diff review, triaging Codex `[P1]`/`[P2]` findings, improvement-pass triage, merge decision | `fable` (claude-fable-5) | `opus` |
-| **Coder** | failing test, implementation, lint/test runs, CHANGELOG, commits, PR creation, applying accepted review fixes and improvement passes | `sonnet` (claude-sonnet-5) | — |
+| **Coder** | failing test, implementation, lint/test runs, CHANGELOG, commits, PR creation, applying accepted review fixes and improvement passes | `opus` (claude-opus-5) | — |
 
 Overrides: `--plan-model=M`, `--code-model=M`, `--review-model=M` (`fable\|opus\|sonnet\|haiku`).
 
 Rules:
 
 1. **Every `Task` launch passes an explicit `model`.** Never inherit the session model.
-2. **Fable fallback:** if a launch with `model: fable` fails because the model is unavailable/invalid/over quota, retry the *identical* launch once with `model: opus` and log `⚠️ fable unavailable — <role> downgraded to opus`. Never fall back to `sonnet` for planner or reviewer roles.
+2. **Fable fallback:** if a launch with `model: fable` fails because the model is unavailable/invalid/over quota, retry the *identical* launch once with `model: opus` and log `⚠️ fable unavailable — <role> downgraded to opus`. Never downgrade a planner or reviewer to a smaller model (`sonnet`/`haiku`).
 3. **Coders never plan.** The coder receives a finished `.pair/PLAN.md`. If it concludes the plan is wrong, it stops and returns `plan_rejected` with evidence — the planner (fable) revises, then the coder resumes.
 4. **Reviewers never write code.** A reviewer emits verdicts and a precise fix list; a coder applies it.
 5. **Codex is unchanged** — external adversarial reviewer on its own default model. Never pass `--model` / `-c model=...` to Codex.
@@ -320,12 +320,12 @@ Work autonomously. Make reasonable decisions. Only ask if truly blocked."
 
 ---
 
-## Implementation Phase (Coder Subagent — model: `sonnet`)
+## Implementation Phase (Coder Subagent — model: `opus`)
 
 Launch a **coder** agent in the planner's worktree. The plan is the contract.
 
 ```
-Use the Task tool with model: "sonnet":
+Use the Task tool with model: "opus":
 
 "Implement GitHub issue #<number> from an already-reviewed plan. You are the CODER — do not re-plan, do not redesign.
 
@@ -426,7 +426,7 @@ Post it on the PR: `gh pr comment <pr> --body "<report>"` — this is the durabl
 
 ### Step 5 — Decision
 
-- **Any ❌ on an `ac` or `test` claim** → the implementation does not meet its own contract. Relaunch a **coder agent (`sonnet`)** in the worktree with the failed claims only — apply the missing piece, commit, push — then relaunch the **reviewer agent (`fable`)** to re-verify **only the failed claims** (not the whole list). Max 2 verify-fix cycles; after that, proceed but mark the final pipeline status **NEEDS ATTENTION** and leave the report as the record.
+- **Any ❌ on an `ac` or `test` claim** → the implementation does not meet its own contract. Relaunch a **coder agent (`opus`)** in the worktree with the failed claims only — apply the missing piece, commit, push — then relaunch the **reviewer agent (`fable`)** to re-verify **only the failed claims** (not the whole list). Max 2 verify-fix cycles; after that, proceed but mark the final pipeline status **NEEDS ATTENTION** and leave the report as the record.
 - **🔀** → non-blocking. The divergence is documented; if the implementation took a *better* path than the plan, fine — the point is it's no longer silent.
 - **➕ unplanned changes** → non-blocking, but they are exactly what the Review Phase should scrutinize first — carry them into the review prompt.
 
@@ -438,8 +438,8 @@ Post it on the PR: `gh pr comment <pr> --body "<report>"` — this is the durabl
 
 There are two review modes. **Full review is the DEFAULT.** Use basic only if `--basic-review` is in `$ARGUMENTS`:
 
-- **Default (full review):** Uses the Claude↔Codex review loop — Codex reviews the PR, a **reviewer agent (`fable`)** triages the [P1]/[P2] findings, a **coder agent (`sonnet`)** applies the accepted fixes and pushes, repeat until Codex approves (max 15 iterations). Codex receives iteration history so it won't re-raise dismissed issues. Thorough (~5-15 min).
-- **`--basic-review` mode:** A **reviewer agent (`fable`)** reviews the PR diff for breaking changes, regressions, debug code, secrets, etc. Fast (~1-2 min). Fixes it requires are applied by a coder agent (`sonnet`).
+- **Default (full review):** Uses the Claude↔Codex review loop — Codex reviews the PR, a **reviewer agent (`fable`)** triages the [P1]/[P2] findings, a **coder agent (`opus`)** applies the accepted fixes and pushes, repeat until Codex approves (max 15 iterations). Codex receives iteration history so it won't re-raise dismissed issues. Thorough (~5-15 min).
+- **`--basic-review` mode:** A **reviewer agent (`fable`)** reviews the PR diff for breaking changes, regressions, debug code, secrets, etc. Fast (~1-2 min). Fixes it requires are applied by a coder agent (`opus`).
 
 If the Verification Phase produced an Implementation Report, include its 🔀 diverged and ➕ unplanned items in the review prompt — they are the highest-priority things for the reviewer to scrutinize.
 
@@ -459,11 +459,11 @@ Run in a reviewer agent (`model: "fable"`, fallback `"opus"`):
 
 Based on the reviewer's verdict:
 - If **SAFE TO MERGE** → Proceed to merge
-- If **NEEDS CHANGES** → hand the fix list to a coder agent (`sonnet`) to apply, or stop and report if the changes are out of scope
+- If **NEEDS CHANGES** → hand the fix list to a coder agent (`opus`) to apply, or stop and report if the changes are out of scope
 
 ### If full review (default):
 
-Run the full Claude↔Codex review loop for this PR, with roles split by model:
+Run the full Claude↔Codex review loop for this PR, with roles split across separate agents:
 
 1. Get PR info: `gh pr view <pr-number> --json title,body,headRefName,baseRefName,files`
 2. Checkout the PR branch: `gh pr checkout <pr-number>`
@@ -478,7 +478,7 @@ Run the full Claude↔Codex review loop for this PR, with roles split by model:
    c. Parse JSONL output for the last `agent_message` text
    d. If no [P1]/[P2] issues → **APPROVED**, break
    e. **Reviewer agent (`model: "fable"`, fallback `"opus"`):** triage each [P1]/[P2] into ACCEPT (real, must fix) or DISMISS (with reason) and emit a precise fix list (`<file>:<line>` — what to change — why). It does not edit files. The fix list must be **self-contained**: exact file, exact line/region, and the current code being changed, so the coder can act without re-reading to locate the site.
-   f. **Coder agent (`model: "sonnet"`):** apply exactly the ACCEPTed fixes, run tests, commit, push. Works from the fix list plus `.pair/CONTEXT.md`; does not re-explore the codebase. If a fix can't be applied as specified, return the reason instead of improvising.
+   f. **Coder agent (`model: "opus"`):** apply exactly the ACCEPTed fixes, run tests, commit, push. Works from the fix list plus `.pair/CONTEXT.md`; does not re-explore the codebase. If a fix can't be applied as specified, return the reason instead of improvising.
    g. Update `ITERATION_HISTORY` with outcomes (FIXED/DISMISSED/NOTED) plus dismissal reasons
    h. Repeat
 
@@ -538,7 +538,7 @@ print(result or '')
 
 If `$IMPROVEMENT_PROMPT` is empty or says "no improvements" → **stop early, don't run pass 2.**
 
-Otherwise: a **reviewer agent (`fable`)** decides which of Codex's suggestions to accept (reject anything that is a rewrite, scope creep, or contradicts the plan), then a **coder agent (`sonnet`)** applies the accepted ones — checkout the PR branch, edit the named files, run tests, commit (`improve: quality pass N`), push.
+Otherwise: a **reviewer agent (`fable`)** decides which of Codex's suggestions to accept (reject anything that is a rewrite, scope creep, or contradicts the plan), then a **coder agent (`opus`)** applies the accepted ones — checkout the PR branch, edit the named files, run tests, commit (`improve: quality pass N`), push.
 
 ---
 
@@ -554,7 +554,7 @@ PR:     #<pr-number>
 Plan:   <plan-review result: reviewed | skipped | unavailable>
 Report: <N as planned · N diverged · N missing · N unplanned | skipped>
 Status: <review result>
-Models: plan=<fable|opus|…> · code=<sonnet|…> · review=<fable|opus|…>
+Models: plan=<fable|opus|…> · code=<opus|…> · review=<fable|opus|…>
 URL:    <pr-url>
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -573,7 +573,7 @@ If any phase fails:
 **Common failure scenarios:**
 - **Issue creation fails:** Check `gh auth status` and repo permissions
 - **Issue number not parsed:** Extract from `gh issue create` output, which prints the URL
-- **`fable` unavailable / invalid model:** retry the same launch once with `model: "opus"`, log the downgrade, continue. Never downgrade a planner or reviewer to `sonnet`.
+- **`fable` unavailable / invalid model:** retry the same launch once with `model: "opus"`, log the downgrade, continue. Never downgrade a planner or reviewer to a smaller model (`sonnet`/`haiku`).
 - **Coder returns `plan_rejected`:** send the reason back to the planner (`fable`), which revises the plan directly, then relaunch the coder. Max 1 round-trip, then report NEEDS ATTENTION.
 - **Subagent fails to create worktree:** Check if directory already exists, or if branch name conflicts
 - **Tests fail:** Report which tests failed and the error output, suggest manual investigation
@@ -584,7 +584,7 @@ If any phase fails:
 ## Notes
 
 - This command uses subagents to maintain context isolation
-- Roles are split by model: planning and reviewing on `fable` (fallback `opus`), code on `sonnet`. A single agent never both plans and implements — that separation is what makes the plan-adherence report meaningful
+- Roles are split across separate agents: planning and reviewing on `fable` (fallback `opus`), code on `opus`. A single agent never both plans and implements — that separation is what makes the plan-adherence report meaningful
 - Each phase runs with fresh context (no /clear needed)
 - Worktrees ensure parallel work doesn't conflict — and must NOT be removed until the Verification Phase has read `.pair/PLAN.md` from them
 - Review happens automatically but human can override


### PR DESCRIPTION
## What

`/drain-issues` and `/issue-pipeline` now write code on **claude-opus-5** instead of claude-sonnet-5. Planning and reviewing are unchanged (`fable`, fallback `opus`).

- `--code-model` default: `sonnet` → `opus`
- **Coder** row in both Model Routing tables → `opus` (claude-opus-5)
- Every coder `Task` launch passes `model: "opus"`: implementation phase, PLAN_NOT_MET fix cycle, Claude↔Codex full-review fix loop, basic-review fixes, improvement passes

## Wording the swap invalidated

- The fable fallback rule justified itself with *"sonnet writes code, it does not plan or judge"* — that rationale is gone. Now: **"never downgrade a planner or reviewer to a smaller model (`sonnet`/`haiku`)"**.
- *"roles split by model"* is no longer literally true with planner-fallback and coder both on opus → **"roles split across separate agents"**. The substantive rules (reviewer never edits files, coder never replans and must return `plan_rejected`) are unchanged.

`sonnet` remains a valid `--plan-model` / `--code-model` / `--review-model` override.

## Also updated

- `README.md`: flag defaults and the two "Model routing" paragraphs / "How it works" steps for both commands
- `CHANGELOG.md`: the model-routing bullet under `[Unreleased]` was describing sonnet-as-coder — updated in place rather than adding a contradicting entry, since it never shipped

Docs only — no executable code in this repo, no CI configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)