### PR TITLE
docs(workflows): planner subagents must run Codex in the foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Types: `Added`, `Changed`, `Fixed`, `Removed`
 
 ### Changed
 
-- **`/drain-issues` planner agents must run Codex in the foreground**: planners were
+- **`/drain-issues` + `/issue-pipeline` planner agents must run Codex in the foreground**: planners were
   launching the plan review with `run_in_background` and ending the turn to wait for a
   task notification that can never arrive — a subagent is not woken by its own background
   task, so the agent went idle until the orchestrator noticed (~20 min lost per planner,
@@ -29,7 +29,7 @@ Types: `Added`, `Changed`, `Fixed`, `Removed`
   (planner, reviewer, coder) invokes `codex exec` as a blocking call and stays in the same
   turn until it returns, polling `BashOutput` in-turn if anything is backgrounded; only the
   main orchestrator loop may background work and rely on being re-invoked. The same rule is
-  repeated inside the planner prompt's plan-review bookkeeping so it lands in the subagent's
+  repeated inside each planner prompt's plan-review bookkeeping so it lands in the subagent's
   own context
 - **`/drain-issues` + `/issue-pipeline` plan review is now a single Codex pass**: the
   two-pass, multi-round loop (Pass A diagnosis, max 2 rounds → Pass B fix-impact, max 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ Types: `Added`, `Changed`, `Fixed`, `Removed`
 
 ### Changed
 
+- **`/drain-issues` planner agents must run Codex in the foreground**: planners were
+  launching the plan review with `run_in_background` and ending the turn to wait for a
+  task notification that can never arrive — a subagent is not woken by its own background
+  task, so the agent went idle until the orchestrator noticed (~20 min lost per planner,
+  observed on two waves). The Model Routing rules now state that every `Task` subagent
+  (planner, reviewer, coder) invokes `codex exec` as a blocking call and stays in the same
+  turn until it returns, polling `BashOutput` in-turn if anything is backgrounded; only the
+  main orchestrator loop may background work and rely on being re-invoked. The same rule is
+  repeated inside the planner prompt's plan-review bookkeeping so it lands in the subagent's
+  own context
 - **`/drain-issues` + `/issue-pipeline` plan review is now a single Codex pass**: the
   two-pass, multi-round loop (Pass A diagnosis, max 2 rounds → Pass B fix-impact, max 3
   rounds, up to 5 Codex calls per issue) collapses into **one** Codex review covering

--- a/drain-issues.md
+++ b/drain-issues.md
@@ -54,7 +54,8 @@ Rules:
 3. **Coder agents never plan.** A coder receives a finished `.pair/PLAN.md` and implements it. If the coder believes the plan is wrong, it stops and returns `"status": "plan_rejected"` with the reason — the planner (fable) revises, then the coder resumes. Coders do not silently redesign.
 4. **Reviewers never write code.** A reviewer produces verdicts and a fix list; the fixes are applied by a coder agent (opus).
 5. **Codex is unchanged** — it stays the external adversarial reviewer on its own default model. Never pass `--model` / `-c model=...` to Codex.
-6. The dependency/wave analysis in Phases 2–3 is planning work; when it is non-trivial (>10 issues or ambiguous chains), delegate it to a planner agent (`fable`) instead of doing it in the main loop.
+6. **Subagents run Codex in the FOREGROUND.** Any agent launched via `Task` (planner, reviewer, coder) must invoke `codex exec` as a **blocking** call and stay in the same turn until it returns. Never start Codex with `run_in_background` and then end the turn waiting for a task notification — **a subagent is not woken by its own background task**, so the turn simply ends and the agent sits idle until the orchestrator notices (observed: ~20 min lost per planner). If something is backgrounded anyway, poll it with `BashOutput` in a loop **within the same turn** until it exits. Only the main orchestrator loop may background work and rely on being re-invoked.
+7. The dependency/wave analysis in Phases 2–3 is planning work; when it is non-trivial (>10 issues or ambiguous chains), delegate it to a planner agent (`fable`) instead of doing it in the main loop.
 
 ---
 
@@ -288,6 +289,7 @@ Goal: ONE adversarial Codex pass over the finished plan, checked against the **a
 **Bookkeeping:**
 - Run Codex from the worktree root so it reads real files.
 - Write the Codex output to `.pair/REVIEW.md` under a `## Codex Plan Review` header.
+- **Run Codex in the FOREGROUND — it is a blocking call.** Do NOT use `run_in_background` and do NOT end your turn waiting for a notification: you are a subagent, nothing will wake you, and the plan review stalls until the orchestrator notices. Normal runtime is 3–10 min — wait it out in this turn. If you background it anyway, poll `BashOutput` in a loop in this same turn until the process exits.
 - Always pipe the prompt via stdin (large prompts as positional args silently hang per CLAUDE.md).
 - Capture stderr — empty stdout ≠ approval. Retry ONCE on empty output. If the second attempt is also empty, log a warning, set `plan_review: "unavailable"`, and hand the unreviewed plan to the coder.
 - Use: `printf '%s' "$PROMPT" | codex exec - -s read-only --ephemeral --json 2> "$CODEX_ERR"` (read-only sandbox signals review intent, faster). `codex exec` is non-interactive and auto-approves within the sandbox — no `-a`/`--ask-for-approval` (that's a global flag and errors after `exec`) and no `--full-auto` (legacy alias; errors on `review`).

--- a/issue-pipeline.md
+++ b/issue-pipeline.md
@@ -56,6 +56,7 @@ Rules:
 3. **Coders never plan.** The coder receives a finished `.pair/PLAN.md`. If it concludes the plan is wrong, it stops and returns `plan_rejected` with evidence — the planner (fable) revises, then the coder resumes.
 4. **Reviewers never write code.** A reviewer emits verdicts and a precise fix list; a coder applies it.
 5. **Codex is unchanged** — external adversarial reviewer on its own default model. Never pass `--model` / `-c model=...` to Codex.
+6. **Subagents run Codex in the FOREGROUND.** Any agent launched via `Task` (planner, reviewer, coder) must invoke `codex exec` as a **blocking** call and stay in the same turn until it returns. Never start Codex with `run_in_background` and then end the turn waiting for a task notification — **a subagent is not woken by its own background task**, so the turn simply ends and the agent sits idle until the orchestrator notices (observed: ~20 min lost per planner). If something is backgrounded anyway, poll it with `BashOutput` in a loop **within the same turn** until it exits. Only the main pipeline loop may background work and rely on being re-invoked.
 
 ---
 
@@ -244,6 +245,7 @@ Goal: ONE adversarial Codex pass over the finished plan, checked against the **a
 **Bookkeeping:**
 - Run Codex from the worktree root so it reads real files.
 - Write the Codex output to `.pair/REVIEW.md` under a `## Codex Plan Review` header.
+- **Run Codex in the FOREGROUND — it is a blocking call.** Do NOT use `run_in_background` and do NOT end your turn waiting for a notification: you are a subagent, nothing will wake you, and the plan review stalls until the pipeline notices. Normal runtime is 3–10 min — wait it out in this turn. If you background it anyway, poll `BashOutput` in a loop in this same turn until the process exits.
 - Always pipe the prompt via stdin (per CLAUDE.md — large prompts as positional args silently hang).
 - Capture stderr — empty stdout ≠ approval. Retry ONCE on empty output; if the second attempt is also empty, log a warning, set `plan_review: "unavailable"`, and hand the unreviewed plan to the coder.
 


### PR DESCRIPTION
## Problem

Two planner agents in the same run stalled at the identical point: each launched the Codex plan review with `run_in_background` and ended its turn waiting for a task notification. That notification can never arrive — **a subagent is not woken by its own background task**. Both sat idle until the orchestrator noticed. ~20 minutes lost per planner.

`/drain-issues` and `/issue-pipeline` share the planner-subagent shape, so both carried the gap.

## Fix

The rule is stated in two places per command, deliberately:

1. **Model Routing → Rules (new rule 6)** — every `Task` subagent (planner, reviewer, coder) invokes `codex exec` as a **blocking foreground call** and stays in the same turn until it returns. If something is backgrounded anyway, poll it with `BashOutput` in a loop *within the same turn*. Only the main orchestrator/pipeline loop may background work and rely on being re-invoked. (In `/drain-issues`, old rule 6 → 7.)

2. **Inside the planner prompt's plan-review bookkeeping** — the rules section is not what a planner reads; the prompt is. Repeating it there is what actually reaches the subagent's context, with the normal 3–10 min Codex runtime spelled out so waiting doesn't look like a hang.

## Files

- `drain-issues.md` — routing rule + planner prompt
- `issue-pipeline.md` — routing rule + planner prompt
- `CHANGELOG.md` — one `Changed` entry under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)